### PR TITLE
Adding archived email to gerrit conversion

### DIFF
--- a/archive_converter.py
+++ b/archive_converter.py
@@ -16,22 +16,19 @@ import email
 from setup_gmail import Message
 
 def generate_email_from_file(file: str):
-    raw_email = open(file, "r")
-    compiled_email = email.message_from_string(raw_email.read())
-    raw_email.close()
-    return email_to_message(compiled_email)
+    with open(file, "r") as raw_email:
+        compiled_email = email.message_from_string(raw_email.read())
+        return _email_to_message(compiled_email)
     
-def email_to_message(compiled_email) -> Message:
+def _email_to_message(compiled_email) -> Message:
     content = []
     if compiled_email.is_multipart():
         for payload in compiled_email.get_payload():
             content.append(payload.get_payload())
     else:
         content = compiled_email.get_payload()
-    return Message(compiled_email['Message-Id'], compiled_email['subject'], compiled_email['from'], compiled_email['In-Reply-To'], content)
-
-def main():
-    generate_email_from_patches("test_data/patch6.txt")
-    
-if __name__ == "__main__":
-    main()
+    return Message(compiled_email['Message-Id'],
+                   compiled_email['subject'],
+                   compiled_email['from'],
+                   compiled_email['In-Reply-To'],
+                   content)

--- a/archive_converter.py
+++ b/archive_converter.py
@@ -1,0 +1,37 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import email
+from setup_gmail import Message
+
+def generate_email_from_file(file: str):
+    raw_email = open(file, "r")
+    compiled_email = email.message_from_string(raw_email.read())
+    raw_email.close()
+    return email_to_message(compiled_email)
+    
+def email_to_message(compiled_email) -> Message:
+    content = []
+    if compiled_email.is_multipart():
+        for payload in compiled_email.get_payload():
+            content.append(payload.get_payload())
+    else:
+        content = compiled_email.get_payload()
+    return Message(compiled_email['Message-Id'], compiled_email['subject'], compiled_email['from'], compiled_email['In-Reply-To'], content)
+
+def main():
+    generate_email_from_patches("test_data/patch6.txt")
+    
+if __name__ == "__main__":
+    main()

--- a/archive_converter_test.py
+++ b/archive_converter_test.py
@@ -1,7 +1,7 @@
 import unittest
 from archive_converter import generate_email_from_file
 
-class TestStringMethods(unittest.TestCase):
+class Archive_Converter_Test(unittest.TestCase):
 
     def test_generate_email_from_single_email_thread(self):
         email = generate_email_from_file("test_data/patch6.txt")

--- a/archive_converter_test.py
+++ b/archive_converter_test.py
@@ -1,0 +1,15 @@
+import unittest
+from archive_converter import generate_email_from_file
+
+class TestStringMethods(unittest.TestCase):
+
+    def test_generate_email_from_single_email_thread(self):
+        email = generate_email_from_file("test_data/patch6.txt")
+        self.assertEqual(email.subject, '[PATCH v2 1/2] Input: i8042 - Prevent intermixing i8042 commands')
+        self.assertEqual(email.in_reply_to, None)
+        self.assertEqual(email.from_, "Raul E Rangel <rrangel@chromium.org>")
+        self.assertTrue(len(email.content) > 0)
+        
+
+if __name__ == '__main__':
+    unittest.main()

--- a/gerrit.py
+++ b/gerrit.py
@@ -29,6 +29,7 @@ from requests.auth import AuthBase
 from http.cookiejar import CookieJar, MozillaCookieJar
 from setup_gmail import Message
 from setup_gmail import find_thread
+from archive_converter import generate_email_from_file
 
 def get_gerrit_rest_api(cookie_jar_path: str, gerrit_url: str) -> GerritRestAPI:
     cookie_jar = MozillaCookieJar(cookie_jar_path)
@@ -120,7 +121,7 @@ def main():
     gerrit_git = GerritGit(git_dir='gerrit_git_dir',
                            cookie_jar_path='gerritcookies',
                            url=gob_url, project='linux/kernel/git/torvalds/linux', branch='master')
-    email_thread = find_thread('PATCH v12 00/18')
+    email_thread = generate_email_from_file("test_data/patch6.txt")
     patchset = parse_comments(email_thread)
     gerrit_git.apply_patchset_and_cleanup(patchset)
     find_and_label_all_revision_ids(gerrit, patchset)

--- a/patch_parser.py
+++ b/patch_parser.py
@@ -350,17 +350,15 @@ def parse_comments(email_thread: Message) -> Patchset:
         comments = []
         for reply in patch.children:
             comments.extend(diff_reply(patch, reply))
-        if (email_thread.in_reply_to):
+        if (len(patches) == 1 and not email_thread.in_reply_to):
+            set_index = 0
+        else:
             set_index, length = parse_set_index(patch)
             assert length == len(patches)
-            text = 'From: {from_}\nSubject: {subject}\n\n{content}'.format(
-                    from_=patch.from_, subject=patch.subject, content=patch.content)
-            patch_list.append(Patch(text=patch.content, text_with_headers=text, set_index=set_index, comments=comments))
-            patch_list.sort(key=lambda x: x.set_index)
-        else:
-            text = 'From: {from_}\nSubject: {subject}\n\n{content}'.format(
-                    from_=patch.from_, subject=patch.subject, content=patch.content)
-            patch_list.append(Patch(text=patch.content, text_with_headers=text, set_index=0, comments=comments))
+        text = 'From: {from_}\nSubject: {subject}\n\n{content}'.format(
+            from_=patch.from_, subject=patch.subject, content=patch.content)
+        patch_list.append(Patch(text=patch.content, text_with_headers=text, set_index=set_index, comments=comments))
+        patch_list.sort(key=lambda x: x.set_index)
     return Patchset(cover_letter=cover_letter, patches=patch_list)
 
 def associate_comments_to_files(patchset: Patchset) -> None:

--- a/patch_parser_test.py
+++ b/patch_parser_test.py
@@ -1,0 +1,20 @@
+import unittest
+from patch_parser import parse_comments
+from archive_converter import generate_email_from_file
+
+class Patch_Parser_Test(unittest.TestCase):
+
+    def test_parse_comments_for_single_email_thread(self):
+        email = generate_email_from_file("test_data/patch6.txt")
+        patchset = parse_comments(email)
+        self.assertTrue(len(patchset.patches) > 0)
+        self.assertTrue(patchset.patches[0].set_index == 0)
+        self.assertTrue(len(patchset.patches[0].text) > 0)
+        self.assertTrue(len(patchset.patches[0].text_with_headers) > 18)
+        self.assertEqual(patchset.patches[0].comments, [])
+        
+    #TODO(willliu@google.com): Add tests for Multiple patches, no cover letter, Multiple patches with cover letter, Email no patches.
+        
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_data/patch4.txt
+++ b/test_data/patch4.txt
@@ -1,0 +1,39 @@
+Return-Path: <linux-kernel-owner+w=401wt.eu-S1751045AbXAVR6a@vger.kernel.org>
+Received: (majordomo@vger.kernel.org) by vger.kernel.org via listexpand
+	id S1751045AbXAVR6a (ORCPT <rfc822;w@1wt.eu>);
+	Mon, 22 Jan 2007 12:58:30 -0500
+Received: (majordomo@vger.kernel.org) by vger.kernel.org id S1751400AbXAVR6a
+	(ORCPT <rfc822;linux-kernel-outgoing>);
+	Mon, 22 Jan 2007 12:58:30 -0500
+Received: from mx1.redhat.com ([66.187.233.31]:60014 "EHLO mx1.redhat.com"
+	rhost-flags-OK-OK-OK-OK) by vger.kernel.org with ESMTP
+	id S1751045AbXAVR63 (ORCPT <rfc822;linux-kernel@vger.kernel.org>);
+	Mon, 22 Jan 2007 12:58:29 -0500
+Subject: Re: [PATCH] Remove final reference to superfluous smp_commence().
+From: Ingo Molnar <mingo@redhat.com>
+To: "Robert P. J. Day" <rpjday@mindspring.com>
+Cc: Linux kernel mailing list <linux-kernel@vger.kernel.org>,
+       Andrew Morton <akpm@osdl.org>
+In-Reply-To: <Pine.LNX.4.64.0701201326330.24479@CPE00045a9c397f-CM001225dbafb6>
+References: <Pine.LNX.4.64.0701201326330.24479@CPE00045a9c397f-CM001225dbafb6>
+Content-Type: text/plain
+Date: Mon, 22 Jan 2007 18:57:50 +0100
+Message-Id: <1169488670.15515.17.camel@earth>
+Mime-Version: 1.0
+X-Mailer: Evolution 2.8.2.1 (2.8.2.1-3.fc6) 
+Content-Transfer-Encoding: 7bit
+Sender: linux-kernel-owner@vger.kernel.org
+X-Mailing-List: linux-kernel@vger.kernel.org
+
+On Sat, 2007-01-20 at 13:28 -0500, Robert P. J. Day wrote:
+> Remove the last (and commented out) invocation of the obsolete
+> smp_commence() call.
+> 
+> Signed-off-by: Robert P. J. Day <rpjday@mindspring.com>
+
+thanks,
+
+Acked-by: Ingo Molnar <mingo@redhat.com>
+
+	Ingo
+

--- a/test_data/patch5.txt
+++ b/test_data/patch5.txt
@@ -1,0 +1,122 @@
+Return-Path: <linux-kernel-owner@vger.kernel.org>
+Received: (majordomo@vger.kernel.org) by vger.kernel.org via listexpand
+	id S1755720Ab3AJTCl (ORCPT <rfc822;w@1wt.eu>);
+	Thu, 10 Jan 2013 14:02:41 -0500
+Received: from mail-vc0-f180.google.com ([209.85.220.180]:61043 "EHLO
+	mail-vc0-f180.google.com" rhost-flags-OK-OK-OK-OK) by vger.kernel.org
+	with ESMTP id S1755647Ab3AJTCf (ORCPT
+	<rfc822;linux-kernel@vger.kernel.org>);
+	Thu, 10 Jan 2013 14:02:35 -0500
+From: Matt Porter <mporter@ti.com>
+To: Vinod Koul <vinod.koul@intel.com>
+Cc: Dan Williams <djbw@fb.com>, Chris Ball <cjb@laptop.org>,
+        Grant Likely <grant.likely@secretlab.ca>,
+        Linux DaVinci Kernel List 
+	<davinci-linux-open-source@linux.davincidsp.com>,
+        Linux Kernel Mailing List <linux-kernel@vger.kernel.org>,
+        Linux MMC List <linux-mmc@vger.kernel.org>
+Subject: [PATCH v2 1/3] dmaengine: add dma_get_channel_caps()
+Date: Thu, 10 Jan 2013 14:07:04 -0500
+Message-Id: <1357844826-30746-2-git-send-email-mporter@ti.com>
+X-Mailer: git-send-email 1.7.9.5
+In-Reply-To: <1357844826-30746-1-git-send-email-mporter@ti.com>
+References: <1357844826-30746-1-git-send-email-mporter@ti.com>
+Sender: linux-kernel-owner@vger.kernel.org
+List-ID: <linux-kernel.vger.kernel.org>
+X-Mailing-List: linux-kernel@vger.kernel.org
+
+Add a dmaengine API to retrieve per channel capabilities.
+Currently, only channel ops and SG segment limitations are
+implemented caps.
+
+The API is optionally implemented by drivers and when
+unimplemented will return a NULL pointer. It is intended
+to be executed after a channel has been requested and, if
+the channel is intended to be used with slave SG transfers,
+then it may only be called after dmaengine_slave_config()
+has executed. The slave driver provides parameters such as
+burst size and address width which may be necessary for
+the dmaengine driver to use in order to properly return SG
+segment limit caps.
+
+Suggested-by: Vinod Koul <vinod.koul@intel.com>
+Signed-off-by: Matt Porter <mporter@ti.com>
+---
+ include/linux/dmaengine.h |   40 ++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 40 insertions(+)
+
+diff --git a/include/linux/dmaengine.h b/include/linux/dmaengine.h
+index c88f302..9fd0c5b 100644
+--- a/include/linux/dmaengine.h
++++ b/include/linux/dmaengine.h
+@@ -371,6 +371,26 @@ struct dma_slave_config {
+ 	unsigned int slave_id;
+ };
+ 
++/* struct dmaengine_chan_caps - expose capability of a channel
++ * Note: each channel can have same or different capabilities
++ *
++ * This primarily classifies capabilities into
++ * a) APIs/ops supported
++ * b) channel physical capabilities
++ *
++ * @cap_mask: api/ops capability (DMA_INTERRUPT and DMA_PRIVATE
++ *	       are invalid api/ops and will never be set)
++ * @seg_nr: maximum number of SG segments supported on a SG/SLAVE
++ *	    channel (0 for no maximum or not a SG/SLAVE channel)
++ * @seg_len: maximum length of SG segments supported on a SG/SLAVE
++ *	     channel (0 for no maximum or not a SG/SLAVE channel)
++ */
++struct dmaengine_chan_caps {
++	dma_cap_mask_t cap_mask;
++	int seg_nr;
++	int seg_len;
++};
++
+ static inline const char *dma_chan_name(struct dma_chan *chan)
+ {
+ 	return dev_name(&chan->dev->device);
+@@ -534,6 +554,7 @@ struct dma_tx_state {
+  *	struct with auxiliary transfer status information, otherwise the call
+  *	will just return a simple status code
+  * @device_issue_pending: push pending transactions to hardware
++ * @device_channel_caps: return the channel capabilities
+  */
+ struct dma_device {
+ 
+@@ -602,6 +623,8 @@ struct dma_device {
+ 					    dma_cookie_t cookie,
+ 					    struct dma_tx_state *txstate);
+ 	void (*device_issue_pending)(struct dma_chan *chan);
++	struct dmaengine_chan_caps *(*device_channel_caps)(
++		struct dma_chan *chan, enum dma_transfer_direction direction);
+ };
+ 
+ static inline int dmaengine_device_control(struct dma_chan *chan,
+@@ -969,6 +992,23 @@ dma_set_tx_state(struct dma_tx_state *st, dma_cookie_t last, dma_cookie_t used,
+ 	}
+ }
+ 
++/**
++ * dma_get_channel_caps - flush pending transactions to HW
++ * @chan: target DMA channel
++ * @dir: direction of transfer
++ *
++ * Get the channel-specific capabilities. If the dmaengine
++ * driver does not implement per channel capbilities then
++ * NULL is returned.
++ */
++static inline struct dmaengine_chan_caps
++*dma_get_channel_caps(struct dma_chan *chan, enum dma_transfer_direction dir)
++{
++	if (chan->device->device_channel_caps)
++		return chan->device->device_channel_caps(chan, dir);
++	return NULL;
++}
++
+ enum dma_status dma_sync_wait(struct dma_chan *chan, dma_cookie_t cookie);
+ #ifdef CONFIG_DMA_ENGINE
+ enum dma_status dma_wait_for_async_tx(struct dma_async_tx_descriptor *tx);
+-- 
+1.7.9.5
+

--- a/test_data/patch6.txt
+++ b/test_data/patch6.txt
@@ -1,0 +1,289 @@
+Return-Path: <SRS0=OCv1=CF=vger.kernel.org=linux-kernel-owner@kernel.org>
+X-Spam-Checker-Version: SpamAssassin 3.4.0 (2014-02-07) on
+	aws-us-west-2-korg-lkml-1.web.codeaurora.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-13.8 required=3.0 tests=BAYES_00,DKIMWL_WL_HIGH,
+	DKIM_SIGNED,DKIM_VALID,DKIM_VALID_AU,HEADER_FROM_DIFFERENT_DOMAINS,
+	INCLUDES_PATCH,MAILING_LIST_MULTI,SIGNED_OFF_BY,SPF_HELO_NONE,SPF_PASS,
+	URIBL_BLOCKED,USER_AGENT_GIT autolearn=ham autolearn_force=no version=3.4.0
+Received: from mail.kernel.org (mail.kernel.org [198.145.29.99])
+	by smtp.lore.kernel.org (Postfix) with ESMTP id 6DA79C433DF
+	for <linux-kernel@archiver.kernel.org>; Thu, 27 Aug 2020 20:42:02 +0000 (UTC)
+Received: from vger.kernel.org (vger.kernel.org [23.128.96.18])
+	by mail.kernel.org (Postfix) with ESMTP id 2962820825
+	for <linux-kernel@archiver.kernel.org>; Thu, 27 Aug 2020 20:42:02 +0000 (UTC)
+Authentication-Results: mail.kernel.org;
+	dkim=pass (1024-bit key) header.d=chromium.org header.i=@chromium.org header.b="hjmK23h2"
+Received: (majordomo@vger.kernel.org) by vger.kernel.org via listexpand
+        id S1727015AbgH0Ul7 (ORCPT
+        <rfc822;linux-kernel@archiver.kernel.org>);
+        Thu, 27 Aug 2020 16:41:59 -0400
+Received: from lindbergh.monkeyblade.net ([23.128.96.19]:59944 "EHLO
+        lindbergh.monkeyblade.net" rhost-flags-OK-OK-OK-OK) by vger.kernel.org
+        with ESMTP id S1726120AbgH0Ul7 (ORCPT
+        <rfc822;linux-kernel@vger.kernel.org>);
+        Thu, 27 Aug 2020 16:41:59 -0400
+Received: from mail-io1-xd42.google.com (mail-io1-xd42.google.com [IPv6:2607:f8b0:4864:20::d42])
+        by lindbergh.monkeyblade.net (Postfix) with ESMTPS id C6B0EC061264
+        for <linux-kernel@vger.kernel.org>; Thu, 27 Aug 2020 13:41:58 -0700 (PDT)
+Received: by mail-io1-xd42.google.com with SMTP id j2so5011242ioj.7
+        for <linux-kernel@vger.kernel.org>; Thu, 27 Aug 2020 13:41:58 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=chromium.org; s=google;
+        h=from:to:cc:subject:date:message-id:mime-version
+         :content-transfer-encoding;
+        bh=OdZ52bJAKfpKjAFikGZ9iZdEwjptrhEb8wvk5fkUSlU=;
+        b=hjmK23h2vxYMNmK6N1yVqijAiSJG+qNNU+BsyUsBkOI/NUftZvTY2xmY1DiUIwJ4cw
+         lGPGoIqNS8b9XiVCBRQXusDK80yQvCCvka9KbaXqF1Fys1BtjDrGwG2k8NSsAZmXWuje
+         sA4Hng9EYxH77vKG49pA8Mf2DR+AL7oTsE/Kk=
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20161025;
+        h=x-gm-message-state:from:to:cc:subject:date:message-id:mime-version
+         :content-transfer-encoding;
+        bh=OdZ52bJAKfpKjAFikGZ9iZdEwjptrhEb8wvk5fkUSlU=;
+        b=PbC2kTOe43epwwU6vY2jT2xek7diy1grh8YHLAi+n1ukKLqIqxKZHYu7emA7vU6Iui
+         a1rdPybQYFIqVBWoYOC0REaNXV8NRmeonXaKuBPKAVhHW1ZO5r5EG7SARABscneDE661
+         9IkFF7jXK78B9whajCUhyqqI3ud654704jIMKzqLYwO3ctzvKJaS+n+JoB418JvEWPU5
+         sdP2JM+R3ZHkeI5RipcLsHZJRkBB4u+0H32pDEwt7CA4majUPQZRFm4mAtCrs/o88W1W
+         xXEnFtIy6aepx4xRmUcVSU1xyvSfFb7Xc1LU5zxjS2d6zENjFJ9DXeFH8DqKtutdsJaf
+         INGA==
+X-Gm-Message-State: AOAM531eKInaMx9W0urA/hskJgew4VH2lQBGHSpscUsqcuKYavNW9FXR
+        dqS0Bzuy0lcwDO3TdSuogWSQYA==
+X-Google-Smtp-Source: ABdhPJy+sf2ZHLgy5mPOmyLAqHckCTewsxG70PYl5CcoNyEnDtbRrrBwT5izhjwvxT+VlCOcPa0d7w==
+X-Received: by 2002:a05:6602:2c03:: with SMTP id w3mr18332842iov.39.1598560918114;
+        Thu, 27 Aug 2020 13:41:58 -0700 (PDT)
+Received: from rrangel920.bld.corp.google.com (h184-60-195-141.arvdco.broadband.dynamic.tds.net. [184.60.195.141])
+        by smtp.gmail.com with ESMTPSA id u17sm1640328ilj.0.2020.08.27.13.41.57
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Thu, 27 Aug 2020 13:41:57 -0700 (PDT)
+From:   Raul E Rangel <rrangel@chromium.org>
+To:     linux-input@vger.kernel.org
+Cc:     dmitry.torokhov@gmail.com, Shirish.S@amd.com,
+        Raul E Rangel <rrangel@chromium.org>,
+        Andy Shevchenko <andy@infradead.org>,
+        Dan Murphy <dmurphy@ti.com>,
+        Darren Hart <dvhart@infradead.org>,
+        Jacek Anaszewski <jacek.anaszewski@gmail.com>,
+        "Lee, Chun-Yi" <jlee@suse.com>, Pavel Machek <pavel@ucw.cz>,
+        Rajat Jain <rajatja@google.com>,
+        Stephen Boyd <swboyd@chromium.org>,
+        linux-kernel@vger.kernel.org, linux-leds@vger.kernel.org,
+        platform-driver-x86@vger.kernel.org
+Subject: [PATCH v2 1/2] Input: i8042 - Prevent intermixing i8042 commands
+Date:   Thu, 27 Aug 2020 14:41:53 -0600
+Message-Id: <20200827144112.v2.1.I6981f9a9f0c12e60f8038f3b574184f8ffc1b9b5@changeid>
+X-Mailer: git-send-email 2.28.0.297.g1956fa8f8d-goog
+MIME-Version: 1.0
+Content-Transfer-Encoding: 8bit
+Sender: linux-kernel-owner@vger.kernel.org
+Precedence: bulk
+List-ID: <linux-kernel.vger.kernel.org>
+X-Mailing-List: linux-kernel@vger.kernel.org
+
+The i8042_mutex must be held by writers of the AUX and KBD ports, as
+well as users of i8042_command. There were a lot of users of
+i8042_command that were not calling i8042_lock_chip/i8042_unlock_chip.
+This resulted in i8042_commands being issues in between PS/2
+transactions.
+
+This change moves the mutex lock into i8042_command and removes the
+burden of locking the mutex from the callers.
+
+It is expected that the i8042_mutex is locked before calling
+i8042_aux_write or i8042_kbd_write. This is currently done by the PS/2
+layer via ps2_begin_command and ps2_end_command. Other modules
+(serio_raw) do not currently lock the mutex, so there is still a
+possibility for intermixed commands.
+
+Link: https://lore.kernel.org/linux-input/CAHQZ30ANTeM-pgdYZ4AbgxsnevBJnJgKZ1Kg+Uy8oSXZUvz=og@mail.gmail.com
+Signed-off-by: Raul E Rangel <rrangel@chromium.org>
+---
+Tested this on a device with only a PS/2 keyboard. I was able to do
+1200+ suspend/resume cycles.
+
+Also tested this on a device with a PS/2 keyboard and a PS/2 mouse.
+I was able to do 250+ iterations with out problems.
+
+Changes in v2:
+- Fixed bad indent
+- Added Link: tag
+- Removed left over rc variable
+
+ drivers/input/serio/i8042.c         | 29 ++++++++++++++---------------
+ drivers/leds/leds-clevo-mail.c      |  9 ---------
+ drivers/platform/x86/acer-wmi.c     |  2 --
+ drivers/platform/x86/amilo-rfkill.c |  6 +-----
+ include/linux/i8042.h               | 10 ----------
+ 5 files changed, 15 insertions(+), 41 deletions(-)
+
+diff --git a/drivers/input/serio/i8042.c b/drivers/input/serio/i8042.c
+index 0dddf273afd94..65ca6b47f41e8 100644
+--- a/drivers/input/serio/i8042.c
++++ b/drivers/input/serio/i8042.c
+@@ -137,8 +137,7 @@ static DEFINE_SPINLOCK(i8042_lock);
+ 
+ /*
+  * Writers to AUX and KBD ports as well as users issuing i8042_command
+- * directly should acquire i8042_mutex (by means of calling
+- * i8042_lock_chip() and i8042_unlock_ship() helpers) to ensure that
++ * directly should acquire i8042_mutex to ensure that
+  * they do not disturb each other (unfortunately in many i8042
+  * implementations write to one of the ports will immediately abort
+  * command that is being processed by another port).
+@@ -173,18 +172,6 @@ static irqreturn_t i8042_interrupt(int irq, void *dev_id);
+ static bool (*i8042_platform_filter)(unsigned char data, unsigned char str,
+ 				     struct serio *serio);
+ 
+-void i8042_lock_chip(void)
+-{
+-	mutex_lock(&i8042_mutex);
+-}
+-EXPORT_SYMBOL(i8042_lock_chip);
+-
+-void i8042_unlock_chip(void)
+-{
+-	mutex_unlock(&i8042_mutex);
+-}
+-EXPORT_SYMBOL(i8042_unlock_chip);
+-
+ int i8042_install_filter(bool (*filter)(unsigned char data, unsigned char str,
+ 					struct serio *serio))
+ {
+@@ -343,10 +330,14 @@ int i8042_command(unsigned char *param, int command)
+ 	unsigned long flags;
+ 	int retval;
+ 
++	mutex_lock(&i8042_mutex);
++
+ 	spin_lock_irqsave(&i8042_lock, flags);
+ 	retval = __i8042_command(param, command);
+ 	spin_unlock_irqrestore(&i8042_lock, flags);
+ 
++	mutex_unlock(&i8042_mutex);
++
+ 	return retval;
+ }
+ EXPORT_SYMBOL(i8042_command);
+@@ -379,10 +370,18 @@ static int i8042_kbd_write(struct serio *port, unsigned char c)
+ static int i8042_aux_write(struct serio *serio, unsigned char c)
+ {
+ 	struct i8042_port *port = serio->port_data;
++	unsigned long flags;
++	int retval = 0;
++
++	spin_lock_irqsave(&i8042_lock, flags);
+ 
+-	return i8042_command(&c, port->mux == -1 ?
++	retval = __i8042_command(&c, port->mux == -1 ?
+ 					I8042_CMD_AUX_SEND :
+ 					I8042_CMD_MUX_SEND + port->mux);
++
++	spin_unlock_irqrestore(&i8042_lock, flags);
++
++	return retval;
+ }
+ 
+ 
+diff --git a/drivers/leds/leds-clevo-mail.c b/drivers/leds/leds-clevo-mail.c
+index f512e99b976b1..6c3d7e54f95cf 100644
+--- a/drivers/leds/leds-clevo-mail.c
++++ b/drivers/leds/leds-clevo-mail.c
+@@ -95,17 +95,12 @@ MODULE_DEVICE_TABLE(dmi, clevo_mail_led_dmi_table);
+ static void clevo_mail_led_set(struct led_classdev *led_cdev,
+ 				enum led_brightness value)
+ {
+-	i8042_lock_chip();
+-
+ 	if (value == LED_OFF)
+ 		i8042_command(NULL, CLEVO_MAIL_LED_OFF);
+ 	else if (value <= LED_HALF)
+ 		i8042_command(NULL, CLEVO_MAIL_LED_BLINK_0_5HZ);
+ 	else
+ 		i8042_command(NULL, CLEVO_MAIL_LED_BLINK_1HZ);
+-
+-	i8042_unlock_chip();
+-
+ }
+ 
+ static int clevo_mail_led_blink(struct led_classdev *led_cdev,
+@@ -114,8 +109,6 @@ static int clevo_mail_led_blink(struct led_classdev *led_cdev,
+ {
+ 	int status = -EINVAL;
+ 
+-	i8042_lock_chip();
+-
+ 	if (*delay_on == 0 /* ms */ && *delay_off == 0 /* ms */) {
+ 		/* Special case: the leds subsystem requested us to
+ 		 * chose one user friendly blinking of the LED, and
+@@ -142,8 +135,6 @@ static int clevo_mail_led_blink(struct led_classdev *led_cdev,
+ 		       *delay_on, *delay_off);
+ 	}
+ 
+-	i8042_unlock_chip();
+-
+ 	return status;
+ }
+ 
+diff --git a/drivers/platform/x86/acer-wmi.c b/drivers/platform/x86/acer-wmi.c
+index 60c18f21588dd..6cb6f800503b2 100644
+--- a/drivers/platform/x86/acer-wmi.c
++++ b/drivers/platform/x86/acer-wmi.c
+@@ -1044,9 +1044,7 @@ static acpi_status WMID_set_u32(u32 value, u32 cap)
+ 			return AE_BAD_PARAMETER;
+ 		if (quirks->mailled == 1) {
+ 			param = value ? 0x92 : 0x93;
+-			i8042_lock_chip();
+ 			i8042_command(&param, 0x1059);
+-			i8042_unlock_chip();
+ 			return 0;
+ 		}
+ 		break;
+diff --git a/drivers/platform/x86/amilo-rfkill.c b/drivers/platform/x86/amilo-rfkill.c
+index 493e169c8f615..c981c6e07ff94 100644
+--- a/drivers/platform/x86/amilo-rfkill.c
++++ b/drivers/platform/x86/amilo-rfkill.c
+@@ -28,12 +28,8 @@
+ static int amilo_a1655_rfkill_set_block(void *data, bool blocked)
+ {
+ 	u8 param = blocked ? A1655_WIFI_OFF : A1655_WIFI_ON;
+-	int rc;
+ 
+-	i8042_lock_chip();
+-	rc = i8042_command(&param, A1655_WIFI_COMMAND);
+-	i8042_unlock_chip();
+-	return rc;
++	return i8042_command(&param, A1655_WIFI_COMMAND);
+ }
+ 
+ static const struct rfkill_ops amilo_a1655_rfkill_ops = {
+diff --git a/include/linux/i8042.h b/include/linux/i8042.h
+index 0261e2fb36364..1c081081c161d 100644
+--- a/include/linux/i8042.h
++++ b/include/linux/i8042.h
+@@ -55,8 +55,6 @@ struct serio;
+ 
+ #if defined(CONFIG_SERIO_I8042) || defined(CONFIG_SERIO_I8042_MODULE)
+ 
+-void i8042_lock_chip(void);
+-void i8042_unlock_chip(void);
+ int i8042_command(unsigned char *param, int command);
+ int i8042_install_filter(bool (*filter)(unsigned char data, unsigned char str,
+ 					struct serio *serio));
+@@ -65,14 +63,6 @@ int i8042_remove_filter(bool (*filter)(unsigned char data, unsigned char str,
+ 
+ #else
+ 
+-static inline void i8042_lock_chip(void)
+-{
+-}
+-
+-static inline void i8042_unlock_chip(void)
+-{
+-}
+-
+ static inline int i8042_command(unsigned char *param, int command)
+ {
+ 	return -ENODEV;
+-- 
+2.28.0.297.g1956fa8f8d-goog
+

--- a/test_data/thread_patch0.txt
+++ b/test_data/thread_patch0.txt
@@ -1,0 +1,112 @@
+Return-Path: <SRS0=vZem=CJ=vger.kernel.org=linux-kselftest-owner@kernel.org>
+X-Spam-Checker-Version: SpamAssassin 3.4.0 (2014-02-07) on
+	aws-us-west-2-korg-lkml-1.web.codeaurora.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-10.0 required=3.0 tests=BAYES_00,
+	HEADER_FROM_DIFFERENT_DOMAINS,MAILING_LIST_MULTI,SIGNED_OFF_BY,SPF_HELO_NONE,
+	SPF_PASS,URIBL_BLOCKED,USER_AGENT_GIT autolearn=unavailable
+	autolearn_force=no version=3.4.0
+Received: from mail.kernel.org (mail.kernel.org [198.145.29.99])
+	by smtp.lore.kernel.org (Postfix) with ESMTP id 5E649C433E2
+	for <linux-kselftest@archiver.kernel.org>; Mon, 31 Aug 2020 11:17:58 +0000 (UTC)
+Received: from vger.kernel.org (vger.kernel.org [23.128.96.18])
+	by mail.kernel.org (Postfix) with ESMTP id 46AFA2068E
+	for <linux-kselftest@archiver.kernel.org>; Mon, 31 Aug 2020 11:17:58 +0000 (UTC)
+Received: (majordomo@vger.kernel.org) by vger.kernel.org via listexpand
+        id S1726771AbgHaLRj (ORCPT
+        <rfc822;linux-kselftest@archiver.kernel.org>);
+        Mon, 31 Aug 2020 07:17:39 -0400
+Received: from foss.arm.com ([217.140.110.172]:56592 "EHLO foss.arm.com"
+        rhost-flags-OK-OK-OK-OK) by vger.kernel.org with ESMTP
+        id S1726472AbgHaLFS (ORCPT <rfc822;linux-kselftest@vger.kernel.org>);
+        Mon, 31 Aug 2020 07:05:18 -0400
+Received: from usa-sjc-imap-foss1.foss.arm.com (unknown [10.121.207.14])
+        by usa-sjc-mx-foss1.foss.arm.com (Postfix) with ESMTP id AAEE61FB;
+        Mon, 31 Aug 2020 04:05:17 -0700 (PDT)
+Received: from e124572.local (unknown [172.31.20.19])
+        by usa-sjc-imap-foss1.foss.arm.com (Postfix) with ESMTPSA id 502E93F71F;
+        Mon, 31 Aug 2020 04:05:15 -0700 (PDT)
+From:   Boyan Karatotev <boyan.karatotev@arm.com>
+To:     linux-arm-kernel@lists.infradead.org,
+        linux-kselftest@vger.kernel.org, linux-kernel@vger.kernel.org
+Cc:     vincenzo.frascino@arm.com, amit.kachhap@arm.com,
+        boian4o1@gmail.com, Boyan Karatotev <boyan.karatotev@arm.com>,
+        Shuah Khan <shuah@kernel.org>,
+        Catalin Marinas <catalin.marinas@arm.com>,
+        Will Deacon <will@kernel.org>
+Subject: [PATCH v2 0/4] kselftests/arm64: add PAuth tests
+Date:   Mon, 31 Aug 2020 12:04:46 +0100
+Message-Id: <20200831110450.30188-1-boyan.karatotev@arm.com>
+X-Mailer: git-send-email 2.17.1
+Sender: linux-kselftest-owner@vger.kernel.org
+Precedence: bulk
+List-ID: <linux-kselftest.vger.kernel.org>
+X-Mailing-List: linux-kselftest@vger.kernel.org
+
+Pointer Authentication (PAuth) is a security feature introduced in ARMv8.3.
+It introduces instructions to sign addresses and later check for potential
+corruption using a second modifier value and one of a set of keys. The
+signature, in the form of the Pointer Authentication Code (PAC), is stored
+in some of the top unused bits of the virtual address (e.g. [54: 49] if
+TBID0 is enabled and TnSZ is set to use a 48 bit VA space). A set of
+controls are present to enable/disable groups of instructions (which use
+certain keys) for compatibility with libraries that do not utilize the
+feature. PAuth is used to verify the integrity of return addresses on the
+stack with less memory than the stack canary.
+
+This patchset adds kselftests to verify the kernel's configuration of the
+feature and its runtime behaviour. There are 7 tests which verify that:
+	* an authentication failure leads to a SIGSEGV
+	* the data/instruction instruction groups are enabled
+	* the generic instructions are enabled
+	* all 5 keys are unique for a single thread
+	* exec() changes all keys to new unique ones
+	* context switching preserves the 4 data/instruction keys
+	* context switching preserves the generic keys
+
+The tests have been verified to work on qemu without a working PAUTH
+Implementation and on ARM's FVP with a full or partial PAuth
+implementation.
+
+Changes in v2:
+* remove extra lines at end of files
+* Patch 1: "kselftests: add a basic arm64 Pointer Authentication test"
+	* add checks for a compatible compiler in Makefile
+* Patch 4: "kselftests: add PAuth tests for single threaded consistency and
+key uniqueness"
+	* rephrase comment for clarity in pac.c
+
+Cc: Shuah Khan <shuah@kernel.org>
+Cc: Catalin Marinas <catalin.marinas@arm.com>
+Cc: Will Deacon <will@kernel.org>
+Reviewed-by: Vincenzo Frascino <Vincenzo.Frascino@arm.com>
+Reviewed-by: Amit Daniel Kachhap <amit.kachhap@arm.com>
+Signed-off-by: Boyan Karatotev <boyan.karatotev@arm.com>
+
+Boyan Karatotev (4):
+  kselftests/arm64: add a basic Pointer Authentication test
+  kselftests/arm64: add nop checks for PAuth tests
+  kselftests/arm64: add PAuth test for whether exec() changes keys
+  kselftests/arm64: add PAuth tests for single threaded consistency and
+    key uniqueness
+
+ tools/testing/selftests/arm64/Makefile        |   2 +-
+ .../testing/selftests/arm64/pauth/.gitignore  |   2 +
+ tools/testing/selftests/arm64/pauth/Makefile  |  39 ++
+ .../selftests/arm64/pauth/exec_target.c       |  35 ++
+ tools/testing/selftests/arm64/pauth/helper.c  |  40 ++
+ tools/testing/selftests/arm64/pauth/helper.h  |  29 ++
+ tools/testing/selftests/arm64/pauth/pac.c     | 348 ++++++++++++++++++
+ .../selftests/arm64/pauth/pac_corruptor.S     |  35 ++
+ 8 files changed, 529 insertions(+), 1 deletion(-)
+ create mode 100644 tools/testing/selftests/arm64/pauth/.gitignore
+ create mode 100644 tools/testing/selftests/arm64/pauth/Makefile
+ create mode 100644 tools/testing/selftests/arm64/pauth/exec_target.c
+ create mode 100644 tools/testing/selftests/arm64/pauth/helper.c
+ create mode 100644 tools/testing/selftests/arm64/pauth/helper.h
+ create mode 100644 tools/testing/selftests/arm64/pauth/pac.c
+ create mode 100644 tools/testing/selftests/arm64/pauth/pac_corruptor.S
+
+--
+2.17.1
+

--- a/test_data/thread_patch1.txt
+++ b/test_data/thread_patch1.txt
@@ -1,0 +1,235 @@
+Return-Path: <SRS0=vZem=CJ=vger.kernel.org=linux-kselftest-owner@kernel.org>
+X-Spam-Checker-Version: SpamAssassin 3.4.0 (2014-02-07) on
+	aws-us-west-2-korg-lkml-1.web.codeaurora.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-13.0 required=3.0 tests=BAYES_00,
+	HEADER_FROM_DIFFERENT_DOMAINS,INCLUDES_PATCH,MAILING_LIST_MULTI,SIGNED_OFF_BY,
+	SPF_HELO_NONE,SPF_PASS,URIBL_BLOCKED,USER_AGENT_GIT autolearn=unavailable
+	autolearn_force=no version=3.4.0
+Received: from mail.kernel.org (mail.kernel.org [198.145.29.99])
+	by smtp.lore.kernel.org (Postfix) with ESMTP id 23F15C433E2
+	for <linux-kselftest@archiver.kernel.org>; Mon, 31 Aug 2020 11:15:53 +0000 (UTC)
+Received: from vger.kernel.org (vger.kernel.org [23.128.96.18])
+	by mail.kernel.org (Postfix) with ESMTP id 0335F2098B
+	for <linux-kselftest@archiver.kernel.org>; Mon, 31 Aug 2020 11:15:53 +0000 (UTC)
+Received: (majordomo@vger.kernel.org) by vger.kernel.org via listexpand
+        id S1726106AbgHaLPi (ORCPT
+        <rfc822;linux-kselftest@archiver.kernel.org>);
+        Mon, 31 Aug 2020 07:15:38 -0400
+Received: from foss.arm.com ([217.140.110.172]:56602 "EHLO foss.arm.com"
+        rhost-flags-OK-OK-OK-OK) by vger.kernel.org with ESMTP
+        id S1726503AbgHaLFV (ORCPT <rfc822;linux-kselftest@vger.kernel.org>);
+        Mon, 31 Aug 2020 07:05:21 -0400
+Received: from usa-sjc-imap-foss1.foss.arm.com (unknown [10.121.207.14])
+        by usa-sjc-mx-foss1.foss.arm.com (Postfix) with ESMTP id D4748101E;
+        Mon, 31 Aug 2020 04:05:20 -0700 (PDT)
+Received: from e124572.local (unknown [172.31.20.19])
+        by usa-sjc-imap-foss1.foss.arm.com (Postfix) with ESMTPSA id 2FA233F71F;
+        Mon, 31 Aug 2020 04:05:17 -0700 (PDT)
+From:   Boyan Karatotev <boyan.karatotev@arm.com>
+To:     linux-arm-kernel@lists.infradead.org,
+        linux-kselftest@vger.kernel.org, linux-kernel@vger.kernel.org
+Cc:     vincenzo.frascino@arm.com, amit.kachhap@arm.com,
+        boian4o1@gmail.com, Boyan Karatotev <boyan.karatotev@arm.com>,
+        Shuah Khan <shuah@kernel.org>,
+        Catalin Marinas <catalin.marinas@arm.com>,
+        Will Deacon <will@kernel.org>
+Subject: [PATCH v2 1/4] kselftests/arm64: add a basic Pointer Authentication test
+Date:   Mon, 31 Aug 2020 12:04:47 +0100
+Message-Id: <20200831110450.30188-2-boyan.karatotev@arm.com>
+X-Mailer: git-send-email 2.17.1
+In-Reply-To: <20200831110450.30188-1-boyan.karatotev@arm.com>
+References: <20200831110450.30188-1-boyan.karatotev@arm.com>
+Sender: linux-kselftest-owner@vger.kernel.org
+Precedence: bulk
+List-ID: <linux-kselftest.vger.kernel.org>
+X-Mailing-List: linux-kselftest@vger.kernel.org
+
+PAuth signs and verifies return addresses on the stack. It does so by
+inserting a Pointer Authentication code (PAC) into some of the unused top
+bits of an address. This is achieved by adding paciasp/autiasp instructions
+at the beginning and end of a function.
+
+This feature is partially backwards compatible with earlier versions of the
+ARM architecture. To coerce the compiler into emitting fully backwards
+compatible code the main file is compiled to target an earlier ARM version.
+This allows the tests to check for the feature and print meaningful error
+messages instead of crashing.
+
+Add a test to verify that corrupting the return address results in a
+SIGSEGV on return.
+
+Cc: Shuah Khan <shuah@kernel.org>
+Cc: Catalin Marinas <catalin.marinas@arm.com>
+Cc: Will Deacon <will@kernel.org>
+Reviewed-by: Vincenzo Frascino <Vincenzo.Frascino@arm.com>
+Reviewed-by: Amit Daniel Kachhap <amit.kachhap@arm.com>
+Signed-off-by: Boyan Karatotev <boyan.karatotev@arm.com>
+---
+ tools/testing/selftests/arm64/Makefile        |  2 +-
+ .../testing/selftests/arm64/pauth/.gitignore  |  1 +
+ tools/testing/selftests/arm64/pauth/Makefile  | 32 +++++++++++++++++
+ tools/testing/selftests/arm64/pauth/helper.h  |  9 +++++
+ tools/testing/selftests/arm64/pauth/pac.c     | 31 ++++++++++++++++
+ .../selftests/arm64/pauth/pac_corruptor.S     | 35 +++++++++++++++++++
+ 6 files changed, 109 insertions(+), 1 deletion(-)
+ create mode 100644 tools/testing/selftests/arm64/pauth/.gitignore
+ create mode 100644 tools/testing/selftests/arm64/pauth/Makefile
+ create mode 100644 tools/testing/selftests/arm64/pauth/helper.h
+ create mode 100644 tools/testing/selftests/arm64/pauth/pac.c
+ create mode 100644 tools/testing/selftests/arm64/pauth/pac_corruptor.S
+
+diff --git a/tools/testing/selftests/arm64/Makefile b/tools/testing/selftests/arm64/Makefile
+index 93b567d23c8b..525506fd97b9 100644
+--- a/tools/testing/selftests/arm64/Makefile
++++ b/tools/testing/selftests/arm64/Makefile
+@@ -4,7 +4,7 @@
+ ARCH ?= $(shell uname -m 2>/dev/null || echo not)
+
+ ifneq (,$(filter $(ARCH),aarch64 arm64))
+-ARM64_SUBTARGETS ?= tags signal
++ARM64_SUBTARGETS ?= tags signal pauth
+ else
+ ARM64_SUBTARGETS :=
+ endif
+diff --git a/tools/testing/selftests/arm64/pauth/.gitignore b/tools/testing/selftests/arm64/pauth/.gitignore
+new file mode 100644
+index 000000000000..b557c916720a
+--- /dev/null
++++ b/tools/testing/selftests/arm64/pauth/.gitignore
+@@ -0,0 +1 @@
++pac
+diff --git a/tools/testing/selftests/arm64/pauth/Makefile b/tools/testing/selftests/arm64/pauth/Makefile
+new file mode 100644
+index 000000000000..01d35aaa610a
+--- /dev/null
++++ b/tools/testing/selftests/arm64/pauth/Makefile
+@@ -0,0 +1,32 @@
++# SPDX-License-Identifier: GPL-2.0
++# Copyright (C) 2020 ARM Limited
++
++# preserve CC value from top level Makefile
++ifeq ($(CC),cc)
++CC := $(CROSS_COMPILE)gcc
++endif
++
++CFLAGS += -mbranch-protection=pac-ret
++# check if the compiler supports ARMv8.3 and branch protection with PAuth
++pauth_cc_support := $(shell if ($(CC) $(CFLAGS) -march=armv8.3-a -E -x c /dev/null -o /dev/null 2>&1) then echo "1"; fi)
++
++ifeq ($(pauth_cc_support),1)
++TEST_GEN_PROGS := pac
++TEST_GEN_FILES := pac_corruptor.o
++endif
++
++include ../../lib.mk
++
++ifeq ($(pauth_cc_support),1)
++# pac* and aut* instructions are not available on architectures berfore
++# ARMv8.3. Therefore target ARMv8.3 wherever they are used directly
++$(OUTPUT)/pac_corruptor.o: pac_corruptor.S
++	$(CC) -c $^ -o $@ $(CFLAGS) -march=armv8.3-a
++
++# when -mbranch-protection is enabled and the target architecture is ARMv8.3 or
++# greater, gcc emits pac* instructions which are not in HINT NOP space,
++# preventing the tests from occurring at all. Compile for ARMv8.2 so tests can
++# run on earlier targets and print a meaningful error messages
++$(OUTPUT)/pac: pac.c $(OUTPUT)/pac_corruptor.o
++	$(CC) $^ -o $@ $(CFLAGS) -march=armv8.2-a
++endif
+diff --git a/tools/testing/selftests/arm64/pauth/helper.h b/tools/testing/selftests/arm64/pauth/helper.h
+new file mode 100644
+index 000000000000..3e0a2a404bf4
+--- /dev/null
++++ b/tools/testing/selftests/arm64/pauth/helper.h
+@@ -0,0 +1,9 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/* Copyright (C) 2020 ARM Limited */
++
++#ifndef _HELPER_H_
++#define _HELPER_H_
++
++void pac_corruptor(void);
++
++#endif
+diff --git a/tools/testing/selftests/arm64/pauth/pac.c b/tools/testing/selftests/arm64/pauth/pac.c
+new file mode 100644
+index 000000000000..7fc02b02dede
+--- /dev/null
++++ b/tools/testing/selftests/arm64/pauth/pac.c
+@@ -0,0 +1,31 @@
++// SPDX-License-Identifier: GPL-2.0
++// Copyright (C) 2020 ARM Limited
++
++#include <sys/auxv.h>
++#include <signal.h>
++
++#include "../../kselftest_harness.h"
++#include "helper.h"
++
++/*
++ * Tests are ARMv8.3 compliant. They make no provisions for features present in
++ * future version of the arm architecture
++ */
++
++#define ASSERT_PAUTH_ENABLED() \
++do { \
++	unsigned long hwcaps = getauxval(AT_HWCAP); \
++	/* data key instructions are not in NOP space. This prevents a SIGILL */ \
++	ASSERT_NE(0, hwcaps & HWCAP_PACA) TH_LOG("PAUTH not enabled"); \
++} while (0)
++
++
++/* check that a corrupted PAC results in SIGSEGV */
++TEST_SIGNAL(corrupt_pac, SIGSEGV)
++{
++	ASSERT_PAUTH_ENABLED();
++
++	pac_corruptor();
++}
++
++TEST_HARNESS_MAIN
+diff --git a/tools/testing/selftests/arm64/pauth/pac_corruptor.S b/tools/testing/selftests/arm64/pauth/pac_corruptor.S
+new file mode 100644
+index 000000000000..0780052ac3b5
+--- /dev/null
++++ b/tools/testing/selftests/arm64/pauth/pac_corruptor.S
+@@ -0,0 +1,35 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/* Copyright (C) 2020 ARM Limited */
++
++.global pac_corruptor
++
++.text
++/*
++ * Corrupting a single bit of the PAC ensures the authentication will fail.  It
++ * also guarantees no possible collision. TCR_EL1.TBI0 is set by default so no
++ * top byte PAC is tested
++ */
++ pac_corruptor:
++	paciasp
++
++	/* make stack frame */
++	sub sp, sp, #16
++	stp x29, lr, [sp]
++	mov x29, sp
++
++	/* prepare mask for bit to be corrupted (bit 54) */
++	mov x1, xzr
++	add x1, x1, #1
++	lsl x1, x1, #54
++
++	/* get saved lr, corrupt selected bit, put it back */
++	ldr x0, [sp, #8]
++	eor x0, x0, x1
++	str x0, [sp, #8]
++
++	/* remove stack frame */
++	ldp x29, lr, [sp]
++	add sp, sp, #16
++
++	autiasp
++	ret
+--
+2.17.1
+

--- a/test_data/thread_patch2.txt
+++ b/test_data/thread_patch2.txt
@@ -1,0 +1,250 @@
+Return-Path: <SRS0=vZem=CJ=vger.kernel.org=linux-kselftest-owner@kernel.org>
+X-Spam-Checker-Version: SpamAssassin 3.4.0 (2014-02-07) on
+	aws-us-west-2-korg-lkml-1.web.codeaurora.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-13.0 required=3.0 tests=BAYES_00,
+	HEADER_FROM_DIFFERENT_DOMAINS,INCLUDES_PATCH,MAILING_LIST_MULTI,SIGNED_OFF_BY,
+	SPF_HELO_NONE,SPF_PASS,URIBL_BLOCKED,USER_AGENT_GIT autolearn=unavailable
+	autolearn_force=no version=3.4.0
+Received: from mail.kernel.org (mail.kernel.org [198.145.29.99])
+	by smtp.lore.kernel.org (Postfix) with ESMTP id 183F5C433E2
+	for <linux-kselftest@archiver.kernel.org>; Mon, 31 Aug 2020 11:16:10 +0000 (UTC)
+Received: from vger.kernel.org (vger.kernel.org [23.128.96.18])
+	by mail.kernel.org (Postfix) with ESMTP id F1AA2208CA
+	for <linux-kselftest@archiver.kernel.org>; Mon, 31 Aug 2020 11:16:09 +0000 (UTC)
+Received: (majordomo@vger.kernel.org) by vger.kernel.org via listexpand
+        id S1726167AbgHaLPM (ORCPT
+        <rfc822;linux-kselftest@archiver.kernel.org>);
+        Mon, 31 Aug 2020 07:15:12 -0400
+Received: from foss.arm.com ([217.140.110.172]:56612 "EHLO foss.arm.com"
+        rhost-flags-OK-OK-OK-OK) by vger.kernel.org with ESMTP
+        id S1726521AbgHaLFY (ORCPT <rfc822;linux-kselftest@vger.kernel.org>);
+        Mon, 31 Aug 2020 07:05:24 -0400
+Received: from usa-sjc-imap-foss1.foss.arm.com (unknown [10.121.207.14])
+        by usa-sjc-mx-foss1.foss.arm.com (Postfix) with ESMTP id 9C1AD11B3;
+        Mon, 31 Aug 2020 04:05:23 -0700 (PDT)
+Received: from e124572.local (unknown [172.31.20.19])
+        by usa-sjc-imap-foss1.foss.arm.com (Postfix) with ESMTPSA id 412293F71F;
+        Mon, 31 Aug 2020 04:05:21 -0700 (PDT)
+From:   Boyan Karatotev <boyan.karatotev@arm.com>
+To:     linux-arm-kernel@lists.infradead.org,
+        linux-kselftest@vger.kernel.org, linux-kernel@vger.kernel.org
+Cc:     vincenzo.frascino@arm.com, amit.kachhap@arm.com,
+        boian4o1@gmail.com, Boyan Karatotev <boyan.karatotev@arm.com>,
+        Shuah Khan <shuah@kernel.org>,
+        Catalin Marinas <catalin.marinas@arm.com>,
+        Will Deacon <will@kernel.org>
+Subject: [PATCH v2 2/4] kselftests/arm64: add nop checks for PAuth tests
+Date:   Mon, 31 Aug 2020 12:04:48 +0100
+Message-Id: <20200831110450.30188-3-boyan.karatotev@arm.com>
+X-Mailer: git-send-email 2.17.1
+In-Reply-To: <20200831110450.30188-1-boyan.karatotev@arm.com>
+References: <20200831110450.30188-1-boyan.karatotev@arm.com>
+Sender: linux-kselftest-owner@vger.kernel.org
+Precedence: bulk
+List-ID: <linux-kselftest.vger.kernel.org>
+X-Mailing-List: linux-kselftest@vger.kernel.org
+
+PAuth adds sign/verify controls to enable and disable groups of
+instructions in hardware for compatibility with libraries that do not
+implement PAuth. The kernel always enables them if it detects PAuth.
+
+Add a test that checks that each group of instructions is enabled, if the
+kernel reports PAuth as detected.
+
+Note: For groups, for the purpose of this patch, we intend instructions
+that use a certain key.
+
+Cc: Shuah Khan <shuah@kernel.org>
+Cc: Catalin Marinas <catalin.marinas@arm.com>
+Cc: Will Deacon <will@kernel.org>
+Reviewed-by: Vincenzo Frascino <Vincenzo.Frascino@arm.com>
+Reviewed-by: Amit Daniel Kachhap <amit.kachhap@arm.com>
+Signed-off-by: Boyan Karatotev <boyan.karatotev@arm.com>
+---
+ .../testing/selftests/arm64/pauth/.gitignore  |  1 +
+ tools/testing/selftests/arm64/pauth/Makefile  |  7 ++-
+ tools/testing/selftests/arm64/pauth/helper.c  | 40 +++++++++++++++
+ tools/testing/selftests/arm64/pauth/helper.h  | 10 ++++
+ tools/testing/selftests/arm64/pauth/pac.c     | 51 +++++++++++++++++++
+ 5 files changed, 107 insertions(+), 2 deletions(-)
+ create mode 100644 tools/testing/selftests/arm64/pauth/helper.c
+
+diff --git a/tools/testing/selftests/arm64/pauth/.gitignore b/tools/testing/selftests/arm64/pauth/.gitignore
+index b557c916720a..155137d92722 100644
+--- a/tools/testing/selftests/arm64/pauth/.gitignore
++++ b/tools/testing/selftests/arm64/pauth/.gitignore
+@@ -1 +1,2 @@
++exec_target
+ pac
+diff --git a/tools/testing/selftests/arm64/pauth/Makefile b/tools/testing/selftests/arm64/pauth/Makefile
+index 01d35aaa610a..5c0dd129562f 100644
+--- a/tools/testing/selftests/arm64/pauth/Makefile
++++ b/tools/testing/selftests/arm64/pauth/Makefile
+@@ -12,7 +12,7 @@ pauth_cc_support := $(shell if ($(CC) $(CFLAGS) -march=armv8.3-a -E -x c /dev/nu
+ 
+ ifeq ($(pauth_cc_support),1)
+ TEST_GEN_PROGS := pac
+-TEST_GEN_FILES := pac_corruptor.o
++TEST_GEN_FILES := pac_corruptor.o helper.o
+ endif
+ 
+ include ../../lib.mk
+@@ -23,10 +23,13 @@ ifeq ($(pauth_cc_support),1)
+ $(OUTPUT)/pac_corruptor.o: pac_corruptor.S
+ 	$(CC) -c $^ -o $@ $(CFLAGS) -march=armv8.3-a
+ 
++$(OUTPUT)/helper.o: helper.c
++	$(CC) -c $^ -o $@ $(CFLAGS) -march=armv8.3-a
++
+ # when -mbranch-protection is enabled and the target architecture is ARMv8.3 or
+ # greater, gcc emits pac* instructions which are not in HINT NOP space,
+ # preventing the tests from occurring at all. Compile for ARMv8.2 so tests can
+ # run on earlier targets and print a meaningful error messages
+-$(OUTPUT)/pac: pac.c $(OUTPUT)/pac_corruptor.o
++$(OUTPUT)/pac: pac.c $(OUTPUT)/pac_corruptor.o $(OUTPUT)/helper.o
+ 	$(CC) $^ -o $@ $(CFLAGS) -march=armv8.2-a
+ endif
+diff --git a/tools/testing/selftests/arm64/pauth/helper.c b/tools/testing/selftests/arm64/pauth/helper.c
+new file mode 100644
+index 000000000000..a5d205fffe6f
+--- /dev/null
++++ b/tools/testing/selftests/arm64/pauth/helper.c
+@@ -0,0 +1,40 @@
++// SPDX-License-Identifier: GPL-2.0
++// Copyright (C) 2020 ARM Limited
++
++#include "helper.h"
++
++
++size_t keyia_sign(size_t ptr)
++{
++	asm volatile("paciza %0" : "+r" (ptr));
++	return ptr;
++}
++
++size_t keyib_sign(size_t ptr)
++{
++	asm volatile("pacizb %0" : "+r" (ptr));
++	return ptr;
++}
++
++size_t keyda_sign(size_t ptr)
++{
++	asm volatile("pacdza %0" : "+r" (ptr));
++	return ptr;
++}
++
++size_t keydb_sign(size_t ptr)
++{
++	asm volatile("pacdzb %0" : "+r" (ptr));
++	return ptr;
++}
++
++size_t keyg_sign(size_t ptr)
++{
++	/* output is encoded in the upper 32 bits */
++	size_t dest = 0;
++	size_t modifier = 0;
++
++	asm volatile("pacga %0, %1, %2" : "=r" (dest) : "r" (ptr), "r" (modifier));
++
++	return dest;
++}
+diff --git a/tools/testing/selftests/arm64/pauth/helper.h b/tools/testing/selftests/arm64/pauth/helper.h
+index 3e0a2a404bf4..e2ed910c9863 100644
+--- a/tools/testing/selftests/arm64/pauth/helper.h
++++ b/tools/testing/selftests/arm64/pauth/helper.h
+@@ -4,6 +4,16 @@
+ #ifndef _HELPER_H_
+ #define _HELPER_H_
+ 
++#include <stdlib.h>
++
++
+ void pac_corruptor(void);
+ 
++/* PAuth sign a value with key ia and modifier value 0 */
++size_t keyia_sign(size_t val);
++size_t keyib_sign(size_t val);
++size_t keyda_sign(size_t val);
++size_t keydb_sign(size_t val);
++size_t keyg_sign(size_t val);
++
+ #endif
+diff --git a/tools/testing/selftests/arm64/pauth/pac.c b/tools/testing/selftests/arm64/pauth/pac.c
+index 7fc02b02dede..035fdd6aae9b 100644
+--- a/tools/testing/selftests/arm64/pauth/pac.c
++++ b/tools/testing/selftests/arm64/pauth/pac.c
+@@ -12,12 +12,25 @@
+  * future version of the arm architecture
+  */
+ 
++#define PAC_COLLISION_ATTEMPTS 10
++/*
++ * The kernel sets TBID by default. So bits 55 and above should remain
++ * untouched no matter what.
++ * The VA space size is 48 bits. Bigger is opt-in.
++ */
++#define PAC_MASK (~0xff80ffffffffffff)
+ #define ASSERT_PAUTH_ENABLED() \
+ do { \
+ 	unsigned long hwcaps = getauxval(AT_HWCAP); \
+ 	/* data key instructions are not in NOP space. This prevents a SIGILL */ \
+ 	ASSERT_NE(0, hwcaps & HWCAP_PACA) TH_LOG("PAUTH not enabled"); \
+ } while (0)
++#define ASSERT_GENERIC_PAUTH_ENABLED() \
++do { \
++	unsigned long hwcaps = getauxval(AT_HWCAP); \
++	/* generic key instructions are not in NOP space. This prevents a SIGILL */ \
++	ASSERT_NE(0, hwcaps & HWCAP_PACG) TH_LOG("Generic PAUTH not enabled"); \
++} while (0)
+ 
+ 
+ /* check that a corrupted PAC results in SIGSEGV */
+@@ -28,4 +41,42 @@ TEST_SIGNAL(corrupt_pac, SIGSEGV)
+ 	pac_corruptor();
+ }
+ 
++/*
++ * There are no separate pac* and aut* controls so checking only the pac*
++ * instructions is sufficient
++ */
++TEST(pac_instructions_not_nop)
++{
++	size_t keyia = 0;
++	size_t keyib = 0;
++	size_t keyda = 0;
++	size_t keydb = 0;
++
++	ASSERT_PAUTH_ENABLED();
++
++	for (int i = 0; i < PAC_COLLISION_ATTEMPTS; i++) {
++		keyia |= keyia_sign(i) & PAC_MASK;
++		keyib |= keyib_sign(i) & PAC_MASK;
++		keyda |= keyda_sign(i) & PAC_MASK;
++		keydb |= keydb_sign(i) & PAC_MASK;
++	}
++
++	ASSERT_NE(0, keyia) TH_LOG("keyia instructions did nothing");
++	ASSERT_NE(0, keyib) TH_LOG("keyib instructions did nothing");
++	ASSERT_NE(0, keyda) TH_LOG("keyda instructions did nothing");
++	ASSERT_NE(0, keydb) TH_LOG("keydb instructions did nothing");
++}
++
++TEST(pac_instructions_not_nop_generic)
++{
++	size_t keyg = 0;
++
++	ASSERT_GENERIC_PAUTH_ENABLED();
++
++	for (int i = 0; i < PAC_COLLISION_ATTEMPTS; i++)
++		keyg |= keyg_sign(i) & PAC_MASK;
++
++	ASSERT_NE(0, keyg)  TH_LOG("keyg instructions did nothing");
++}
++
+ TEST_HARNESS_MAIN
+-- 
+2.17.1
+

--- a/test_data/thread_patch3.txt
+++ b/test_data/thread_patch3.txt
@@ -1,0 +1,323 @@
+Return-Path: <SRS0=vZem=CJ=vger.kernel.org=linux-kselftest-owner@kernel.org>
+X-Spam-Checker-Version: SpamAssassin 3.4.0 (2014-02-07) on
+	aws-us-west-2-korg-lkml-1.web.codeaurora.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-13.0 required=3.0 tests=BAYES_00,
+	HEADER_FROM_DIFFERENT_DOMAINS,INCLUDES_PATCH,MAILING_LIST_MULTI,SIGNED_OFF_BY,
+	SPF_HELO_NONE,SPF_PASS,USER_AGENT_GIT autolearn=unavailable
+	autolearn_force=no version=3.4.0
+Received: from mail.kernel.org (mail.kernel.org [198.145.29.99])
+	by smtp.lore.kernel.org (Postfix) with ESMTP id 538D4C433E6
+	for <linux-kselftest@archiver.kernel.org>; Mon, 31 Aug 2020 11:13:55 +0000 (UTC)
+Received: from vger.kernel.org (vger.kernel.org [23.128.96.18])
+	by mail.kernel.org (Postfix) with ESMTP id 338C6214D8
+	for <linux-kselftest@archiver.kernel.org>; Mon, 31 Aug 2020 11:13:55 +0000 (UTC)
+Received: (majordomo@vger.kernel.org) by vger.kernel.org via listexpand
+        id S1726572AbgHaLKE (ORCPT
+        <rfc822;linux-kselftest@archiver.kernel.org>);
+        Mon, 31 Aug 2020 07:10:04 -0400
+Received: from foss.arm.com ([217.140.110.172]:56620 "EHLO foss.arm.com"
+        rhost-flags-OK-OK-OK-OK) by vger.kernel.org with ESMTP
+        id S1726522AbgHaLF1 (ORCPT <rfc822;linux-kselftest@vger.kernel.org>);
+        Mon, 31 Aug 2020 07:05:27 -0400
+Received: from usa-sjc-imap-foss1.foss.arm.com (unknown [10.121.207.14])
+        by usa-sjc-mx-foss1.foss.arm.com (Postfix) with ESMTP id 8C62B11D4;
+        Mon, 31 Aug 2020 04:05:26 -0700 (PDT)
+Received: from e124572.local (unknown [172.31.20.19])
+        by usa-sjc-imap-foss1.foss.arm.com (Postfix) with ESMTPSA id 07AE53F71F;
+        Mon, 31 Aug 2020 04:05:23 -0700 (PDT)
+From:   Boyan Karatotev <boyan.karatotev@arm.com>
+To:     linux-arm-kernel@lists.infradead.org,
+        linux-kselftest@vger.kernel.org, linux-kernel@vger.kernel.org
+Cc:     vincenzo.frascino@arm.com, amit.kachhap@arm.com,
+        boian4o1@gmail.com, Boyan Karatotev <boyan.karatotev@arm.com>,
+        Shuah Khan <shuah@kernel.org>,
+        Catalin Marinas <catalin.marinas@arm.com>,
+        Will Deacon <will@kernel.org>
+Subject: [PATCH v2 3/4] kselftests/arm64: add PAuth test for whether exec() changes keys
+Date:   Mon, 31 Aug 2020 12:04:49 +0100
+Message-Id: <20200831110450.30188-4-boyan.karatotev@arm.com>
+X-Mailer: git-send-email 2.17.1
+In-Reply-To: <20200831110450.30188-1-boyan.karatotev@arm.com>
+References: <20200831110450.30188-1-boyan.karatotev@arm.com>
+Sender: linux-kselftest-owner@vger.kernel.org
+Precedence: bulk
+List-ID: <linux-kselftest.vger.kernel.org>
+X-Mailing-List: linux-kselftest@vger.kernel.org
+
+Kernel documentation states that it will change PAuth keys on exec() calls.
+
+Verify that all keys are correctly switched to new ones.
+
+Cc: Shuah Khan <shuah@kernel.org>
+Cc: Catalin Marinas <catalin.marinas@arm.com>
+Cc: Will Deacon <will@kernel.org>
+Reviewed-by: Vincenzo Frascino <Vincenzo.Frascino@arm.com>
+Reviewed-by: Amit Daniel Kachhap <amit.kachhap@arm.com>
+Signed-off-by: Boyan Karatotev <boyan.karatotev@arm.com>
+---
+ tools/testing/selftests/arm64/pauth/Makefile  |   4 +
+ .../selftests/arm64/pauth/exec_target.c       |  35 +++++
+ tools/testing/selftests/arm64/pauth/helper.h  |  10 ++
+ tools/testing/selftests/arm64/pauth/pac.c     | 148 ++++++++++++++++++
+ 4 files changed, 197 insertions(+)
+ create mode 100644 tools/testing/selftests/arm64/pauth/exec_target.c
+
+diff --git a/tools/testing/selftests/arm64/pauth/Makefile b/tools/testing/selftests/arm64/pauth/Makefile
+index 5c0dd129562f..72e290b0b10c 100644
+--- a/tools/testing/selftests/arm64/pauth/Makefile
++++ b/tools/testing/selftests/arm64/pauth/Makefile
+@@ -13,6 +13,7 @@ pauth_cc_support := $(shell if ($(CC) $(CFLAGS) -march=armv8.3-a -E -x c /dev/nu
+ ifeq ($(pauth_cc_support),1)
+ TEST_GEN_PROGS := pac
+ TEST_GEN_FILES := pac_corruptor.o helper.o
++TEST_GEN_PROGS_EXTENDED := exec_target
+ endif
+ 
+ include ../../lib.mk
+@@ -30,6 +31,9 @@ $(OUTPUT)/helper.o: helper.c
+ # greater, gcc emits pac* instructions which are not in HINT NOP space,
+ # preventing the tests from occurring at all. Compile for ARMv8.2 so tests can
+ # run on earlier targets and print a meaningful error messages
++$(OUTPUT)/exec_target: exec_target.c $(OUTPUT)/helper.o
++	$(CC) $^ -o $@ $(CFLAGS) -march=armv8.2-a
++
+ $(OUTPUT)/pac: pac.c $(OUTPUT)/pac_corruptor.o $(OUTPUT)/helper.o
+ 	$(CC) $^ -o $@ $(CFLAGS) -march=armv8.2-a
+ endif
+diff --git a/tools/testing/selftests/arm64/pauth/exec_target.c b/tools/testing/selftests/arm64/pauth/exec_target.c
+new file mode 100644
+index 000000000000..07addef5a1d7
+--- /dev/null
++++ b/tools/testing/selftests/arm64/pauth/exec_target.c
+@@ -0,0 +1,35 @@
++// SPDX-License-Identifier: GPL-2.0
++// Copyright (C) 2020 ARM Limited
++
++#include <stdio.h>
++#include <stdlib.h>
++#include <sys/auxv.h>
++
++#include "helper.h"
++
++
++int main(void)
++{
++	struct signatures signed_vals;
++	unsigned long hwcaps;
++	size_t val;
++
++	fread(&val, sizeof(size_t), 1, stdin);
++
++	/* don't try to execute illegal (unimplemented) instructions) caller
++	 * should have checked this and keep worker simple
++	 */
++	hwcaps = getauxval(AT_HWCAP);
++
++	if (hwcaps & HWCAP_PACA) {
++		signed_vals.keyia = keyia_sign(val);
++		signed_vals.keyib = keyib_sign(val);
++		signed_vals.keyda = keyda_sign(val);
++		signed_vals.keydb = keydb_sign(val);
++	}
++	signed_vals.keyg = (hwcaps & HWCAP_PACG) ?  keyg_sign(val) : 0;
++
++	fwrite(&signed_vals, sizeof(struct signatures), 1, stdout);
++
++	return 0;
++}
+diff --git a/tools/testing/selftests/arm64/pauth/helper.h b/tools/testing/selftests/arm64/pauth/helper.h
+index e2ed910c9863..da6457177727 100644
+--- a/tools/testing/selftests/arm64/pauth/helper.h
++++ b/tools/testing/selftests/arm64/pauth/helper.h
+@@ -6,6 +6,16 @@
+ 
+ #include <stdlib.h>
+ 
++#define NKEYS 5
++
++
++struct signatures {
++	size_t keyia;
++	size_t keyib;
++	size_t keyda;
++	size_t keydb;
++	size_t keyg;
++};
+ 
+ void pac_corruptor(void);
+ 
+diff --git a/tools/testing/selftests/arm64/pauth/pac.c b/tools/testing/selftests/arm64/pauth/pac.c
+index 035fdd6aae9b..1b9e3acfeb61 100644
+--- a/tools/testing/selftests/arm64/pauth/pac.c
++++ b/tools/testing/selftests/arm64/pauth/pac.c
+@@ -2,6 +2,8 @@
+ // Copyright (C) 2020 ARM Limited
+ 
+ #include <sys/auxv.h>
++#include <sys/types.h>
++#include <sys/wait.h>
+ #include <signal.h>
+ 
+ #include "../../kselftest_harness.h"
+@@ -33,6 +35,117 @@ do { \
+ } while (0)
+ 
+ 
++void sign_specific(struct signatures *sign, size_t val)
++{
++	sign->keyia = keyia_sign(val);
++	sign->keyib = keyib_sign(val);
++	sign->keyda = keyda_sign(val);
++	sign->keydb = keydb_sign(val);
++}
++
++void sign_all(struct signatures *sign, size_t val)
++{
++	sign->keyia = keyia_sign(val);
++	sign->keyib = keyib_sign(val);
++	sign->keyda = keyda_sign(val);
++	sign->keydb = keydb_sign(val);
++	sign->keyg  = keyg_sign(val);
++}
++
++int are_same(struct signatures *old, struct signatures *new, int nkeys)
++{
++	int res = 0;
++
++	res |= old->keyia == new->keyia;
++	res |= old->keyib == new->keyib;
++	res |= old->keyda == new->keyda;
++	res |= old->keydb == new->keydb;
++	if (nkeys == NKEYS)
++		res |= old->keyg  == new->keyg;
++
++	return res;
++}
++
++int exec_sign_all(struct signatures *signed_vals, size_t val)
++{
++	int new_stdin[2];
++	int new_stdout[2];
++	int status;
++	ssize_t ret;
++	pid_t pid;
++
++	ret = pipe(new_stdin);
++	if (ret == -1) {
++		perror("pipe returned error");
++		return -1;
++	}
++
++	ret = pipe(new_stdout);
++	if (ret == -1) {
++		perror("pipe returned error");
++		return -1;
++	}
++
++	pid = fork();
++	// child
++	if (pid == 0) {
++		dup2(new_stdin[0], STDIN_FILENO);
++		if (ret == -1) {
++			perror("dup2 returned error");
++			exit(1);
++		}
++
++		dup2(new_stdout[1], STDOUT_FILENO);
++		if (ret == -1) {
++			perror("dup2 returned error");
++			exit(1);
++		}
++
++		close(new_stdin[0]);
++		close(new_stdin[1]);
++		close(new_stdout[0]);
++		close(new_stdout[1]);
++
++		ret = execl("exec_target", "exec_target", (char *) NULL);
++		if (ret == -1) {
++			perror("exec returned error");
++			exit(1);
++		}
++	}
++
++	close(new_stdin[0]);
++	close(new_stdout[1]);
++
++	ret = write(new_stdin[1], &val, sizeof(size_t));
++	if (ret == -1) {
++		perror("write returned error");
++		return -1;
++	}
++
++	/*
++	 * wait for the worker to finish, so that read() reads all data
++	 * will also context switch with worker so that this function can be used
++	 * for context switch tests
++	 */
++	waitpid(pid, &status, 0);
++	if (WIFEXITED(status) == 0) {
++		fprintf(stderr, "worker exited unexpectedly\n");
++		return -1;
++	}
++	if (WEXITSTATUS(status) != 0) {
++		fprintf(stderr, "worker exited with error\n");
++		return -1;
++	}
++
++	ret = read(new_stdout[0], signed_vals, sizeof(struct signatures));
++	if (ret == -1) {
++		perror("read returned error");
++		return -1;
++	}
++
++	return 0;
++}
++
+ /* check that a corrupted PAC results in SIGSEGV */
+ TEST_SIGNAL(corrupt_pac, SIGSEGV)
+ {
+@@ -79,4 +192,39 @@ TEST(pac_instructions_not_nop_generic)
+ 	ASSERT_NE(0, keyg)  TH_LOG("keyg instructions did nothing");
+ }
+ 
++/*
++ * fork() does not change keys. Only exec() does so call a worker program.
++ * Its only job is to sign a value and report back the resutls
++ */
++TEST(exec_unique_keys)
++{
++	struct signatures new_keys;
++	struct signatures old_keys;
++	int ret;
++	int different = 0;
++	int nkeys = NKEYS;
++	unsigned long hwcaps = getauxval(AT_HWCAP);
++
++	/* generic and data key instructions are not in NOP space. This prevents a SIGILL */
++	ASSERT_NE(0, hwcaps & HWCAP_PACA) TH_LOG("PAUTH not enabled");
++	if (!(hwcaps & HWCAP_PACG)) {
++		TH_LOG("WARNING: Generic PAUTH not enabled. Skipping generic key checks");
++		nkeys = NKEYS - 1;
++	}
++
++	for (int i = 0; i < PAC_COLLISION_ATTEMPTS; i++) {
++		ret = exec_sign_all(&new_keys, i);
++		ASSERT_EQ(0, ret) TH_LOG("failed to run worker");
++
++		if (nkeys == NKEYS)
++			sign_all(&old_keys, i);
++		else
++			sign_specific(&old_keys, i);
++
++		different |= !are_same(&old_keys, &new_keys, nkeys);
++	}
++
++	ASSERT_EQ(1, different) TH_LOG("exec() did not change keys");
++}
++
+ TEST_HARNESS_MAIN
+-- 
+2.17.1
+

--- a/test_data/thread_patch4.txt
+++ b/test_data/thread_patch4.txt
@@ -1,0 +1,238 @@
+Return-Path: <SRS0=vZem=CJ=vger.kernel.org=linux-kselftest-owner@kernel.org>
+X-Spam-Checker-Version: SpamAssassin 3.4.0 (2014-02-07) on
+	aws-us-west-2-korg-lkml-1.web.codeaurora.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-13.0 required=3.0 tests=BAYES_00,
+	HEADER_FROM_DIFFERENT_DOMAINS,INCLUDES_PATCH,MAILING_LIST_MULTI,SIGNED_OFF_BY,
+	SPF_HELO_NONE,SPF_PASS,URIBL_BLOCKED,USER_AGENT_GIT autolearn=unavailable
+	autolearn_force=no version=3.4.0
+Received: from mail.kernel.org (mail.kernel.org [198.145.29.99])
+	by smtp.lore.kernel.org (Postfix) with ESMTP id A8785C433E2
+	for <linux-kselftest@archiver.kernel.org>; Mon, 31 Aug 2020 11:15:38 +0000 (UTC)
+Received: from vger.kernel.org (vger.kernel.org [23.128.96.18])
+	by mail.kernel.org (Postfix) with ESMTP id 908132068E
+	for <linux-kselftest@archiver.kernel.org>; Mon, 31 Aug 2020 11:15:38 +0000 (UTC)
+Received: (majordomo@vger.kernel.org) by vger.kernel.org via listexpand
+        id S1726292AbgHaLKr (ORCPT
+        <rfc822;linux-kselftest@archiver.kernel.org>);
+        Mon, 31 Aug 2020 07:10:47 -0400
+Received: from foss.arm.com ([217.140.110.172]:56636 "EHLO foss.arm.com"
+        rhost-flags-OK-OK-OK-OK) by vger.kernel.org with ESMTP
+        id S1726523AbgHaLFe (ORCPT <rfc822;linux-kselftest@vger.kernel.org>);
+        Mon, 31 Aug 2020 07:05:34 -0400
+Received: from usa-sjc-imap-foss1.foss.arm.com (unknown [10.121.207.14])
+        by usa-sjc-mx-foss1.foss.arm.com (Postfix) with ESMTP id 4129B12FC;
+        Mon, 31 Aug 2020 04:05:29 -0700 (PDT)
+Received: from e124572.local (unknown [172.31.20.19])
+        by usa-sjc-imap-foss1.foss.arm.com (Postfix) with ESMTPSA id D10293F71F;
+        Mon, 31 Aug 2020 04:05:26 -0700 (PDT)
+From:   Boyan Karatotev <boyan.karatotev@arm.com>
+To:     linux-arm-kernel@lists.infradead.org,
+        linux-kselftest@vger.kernel.org, linux-kernel@vger.kernel.org
+Cc:     vincenzo.frascino@arm.com, amit.kachhap@arm.com,
+        boian4o1@gmail.com, Boyan Karatotev <boyan.karatotev@arm.com>,
+        Shuah Khan <shuah@kernel.org>,
+        Catalin Marinas <catalin.marinas@arm.com>,
+        Will Deacon <will@kernel.org>
+Subject: [PATCH v2 4/4] kselftests/arm64: add PAuth tests for single threaded consistency and key uniqueness
+Date:   Mon, 31 Aug 2020 12:04:50 +0100
+Message-Id: <20200831110450.30188-5-boyan.karatotev@arm.com>
+X-Mailer: git-send-email 2.17.1
+In-Reply-To: <20200831110450.30188-1-boyan.karatotev@arm.com>
+References: <20200831110450.30188-1-boyan.karatotev@arm.com>
+Sender: linux-kselftest-owner@vger.kernel.org
+Precedence: bulk
+List-ID: <linux-kselftest.vger.kernel.org>
+X-Mailing-List: linux-kselftest@vger.kernel.org
+
+PAuth adds 5 different keys that can be used to sign addresses.
+
+Add a test that verifies that the kernel initializes them uniquely and
+preserves them across context switches.
+
+Cc: Shuah Khan <shuah@kernel.org>
+Cc: Catalin Marinas <catalin.marinas@arm.com>
+Cc: Will Deacon <will@kernel.org>
+Reviewed-by: Vincenzo Frascino <Vincenzo.Frascino@arm.com>
+Reviewed-by: Amit Daniel Kachhap <amit.kachhap@arm.com>
+Signed-off-by: Boyan Karatotev <boyan.karatotev@arm.com>
+---
+ tools/testing/selftests/arm64/pauth/pac.c | 118 ++++++++++++++++++++++
+ 1 file changed, 118 insertions(+)
+
+diff --git a/tools/testing/selftests/arm64/pauth/pac.c b/tools/testing/selftests/arm64/pauth/pac.c
+index 1b9e3acfeb61..7d0ba2ec2e9e 100644
+--- a/tools/testing/selftests/arm64/pauth/pac.c
++++ b/tools/testing/selftests/arm64/pauth/pac.c
+@@ -1,10 +1,13 @@
+ // SPDX-License-Identifier: GPL-2.0
+ // Copyright (C) 2020 ARM Limited
+ 
++#define _GNU_SOURCE
++
+ #include <sys/auxv.h>
+ #include <sys/types.h>
+ #include <sys/wait.h>
+ #include <signal.h>
++#include <sched.h>
+ 
+ #include "../../kselftest_harness.h"
+ #include "helper.h"
+@@ -21,6 +24,7 @@
+  * The VA space size is 48 bits. Bigger is opt-in.
+  */
+ #define PAC_MASK (~0xff80ffffffffffff)
++#define ARBITRARY_VALUE (0x1234)
+ #define ASSERT_PAUTH_ENABLED() \
+ do { \
+ 	unsigned long hwcaps = getauxval(AT_HWCAP); \
+@@ -66,13 +70,36 @@ int are_same(struct signatures *old, struct signatures *new, int nkeys)
+ 	return res;
+ }
+ 
++int are_unique(struct signatures *sign, int nkeys)
++{
++	size_t vals[nkeys];
++
++	vals[0] = sign->keyia & PAC_MASK;
++	vals[1] = sign->keyib & PAC_MASK;
++	vals[2] = sign->keyda & PAC_MASK;
++	vals[3] = sign->keydb & PAC_MASK;
++
++	if (nkeys >= 4)
++		vals[4] = sign->keyg & PAC_MASK;
++
++	for (int i = 0; i < nkeys - 1; i++) {
++		for (int j = i + 1; j < nkeys; j++) {
++			if (vals[i] == vals[j])
++				return 0;
++		}
++	}
++	return 1;
++}
++
+ int exec_sign_all(struct signatures *signed_vals, size_t val)
+ {
+ 	int new_stdin[2];
+ 	int new_stdout[2];
+ 	int status;
++	int i;
+ 	ssize_t ret;
+ 	pid_t pid;
++	cpu_set_t mask;
+ 
+ 	ret = pipe(new_stdin);
+ 	if (ret == -1) {
+@@ -86,6 +113,20 @@ int exec_sign_all(struct signatures *signed_vals, size_t val)
+ 		return -1;
+ 	}
+ 
++	/*
++	 * pin this process and all its children to a single CPU, so it can also
++	 * guarantee a context switch with its child
++	 */
++	sched_getaffinity(0, sizeof(mask), &mask);
++
++	for (i = 0; i < sizeof(cpu_set_t); i++)
++		if (CPU_ISSET(i, &mask))
++			break;
++
++	CPU_ZERO(&mask);
++	CPU_SET(i, &mask);
++	sched_setaffinity(0, sizeof(mask), &mask);
++
+ 	pid = fork();
+ 	// child
+ 	if (pid == 0) {
+@@ -192,6 +233,40 @@ TEST(pac_instructions_not_nop_generic)
+ 	ASSERT_NE(0, keyg)  TH_LOG("keyg instructions did nothing");
+ }
+ 
++TEST(single_thread_unique_keys)
++{
++	int unique = 0;
++	int nkeys = NKEYS;
++	struct signatures signed_vals;
++	unsigned long hwcaps = getauxval(AT_HWCAP);
++
++	/* generic and data key instructions are not in NOP space. This prevents a SIGILL */
++	ASSERT_NE(0, hwcaps & HWCAP_PACA) TH_LOG("PAUTH not enabled");
++	if (!(hwcaps & HWCAP_PACG)) {
++		TH_LOG("WARNING: Generic PAUTH not enabled. Skipping generic key checks");
++		nkeys = NKEYS - 1;
++	}
++
++	/*
++	 * In Linux the PAC field can be up to 7 bits wide. Even if keys are
++	 * unique, there is about 5% chance for PACs to collide with different
++	 * addresses. This chance rapidly increases with fewer bits allocated
++	 * for the PAC (e.g. wider address). A comparison of the keys directly
++	 * will be more reliable.
++	 * All signed values need to be unique at least once out of n attempts
++	 * to be certain that the keys are unique
++	 */
++	for (int i = 0; i < PAC_COLLISION_ATTEMPTS; i++) {
++		if (nkeys == NKEYS)
++			sign_all(&signed_vals, i);
++		else
++			sign_specific(&signed_vals, i);
++		unique |= are_unique(&signed_vals, nkeys);
++	}
++
++	ASSERT_EQ(1, unique) TH_LOG("keys clashed every time");
++}
++
+ /*
+  * fork() does not change keys. Only exec() does so call a worker program.
+  * Its only job is to sign a value and report back the resutls
+@@ -227,4 +302,47 @@ TEST(exec_unique_keys)
+ 	ASSERT_EQ(1, different) TH_LOG("exec() did not change keys");
+ }
+ 
++TEST(context_switch_keep_keys)
++{
++	int ret;
++	struct signatures trash;
++	struct signatures before;
++	struct signatures after;
++
++	ASSERT_PAUTH_ENABLED();
++
++	sign_specific(&before, ARBITRARY_VALUE);
++
++	/* will context switch with a process with different keys at least once */
++	ret = exec_sign_all(&trash, ARBITRARY_VALUE);
++	ASSERT_EQ(0, ret) TH_LOG("failed to run worker");
++
++	sign_specific(&after, ARBITRARY_VALUE);
++
++	ASSERT_EQ(before.keyia, after.keyia) TH_LOG("keyia changed after context switching");
++	ASSERT_EQ(before.keyib, after.keyib) TH_LOG("keyib changed after context switching");
++	ASSERT_EQ(before.keyda, after.keyda) TH_LOG("keyda changed after context switching");
++	ASSERT_EQ(before.keydb, after.keydb) TH_LOG("keydb changed after context switching");
++}
++
++TEST(context_switch_keep_keys_generic)
++{
++	int ret;
++	struct signatures trash;
++	size_t before;
++	size_t after;
++
++	ASSERT_GENERIC_PAUTH_ENABLED();
++
++	before = keyg_sign(ARBITRARY_VALUE);
++
++	/* will context switch with a process with different keys at least once */
++	ret = exec_sign_all(&trash, ARBITRARY_VALUE);
++	ASSERT_EQ(0, ret) TH_LOG("failed to run worker");
++
++	after = keyg_sign(ARBITRARY_VALUE);
++
++	ASSERT_EQ(before, after) TH_LOG("keyg changed after context switching");
++}
++
+ TEST_HARNESS_MAIN
+-- 
+2.17.1
+


### PR DESCRIPTION
This feature allows for single email threads to be converted to Gerrit. Link to Gerrit: https://linux-review.googlesource.com/c/linux/kernel/git/torvalds/linux/+/2781