### PR TITLE
Small miscellaneous cleanups regarding imports

### DIFF
--- a/src/gerrit.py
+++ b/src/gerrit.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from typing import Dict, List
 import base64
 import pickle

--- a/src/gerrit.py
+++ b/src/gerrit.py
@@ -74,7 +74,7 @@ class Gerrit(object):
                         revision_id=revision_id),
                 data=review)
 
-def find_and_label_revision_id(gerrit: Gerrit, patch: Patch):
+def _find_and_label_revision_id(gerrit: Gerrit, patch: Patch):
     change_info = gerrit.get_change(patch.change_id)
     logging.info('Change info: %s', change_info)
     revision_id = change_info['current_revision']
@@ -83,7 +83,7 @@ def find_and_label_revision_id(gerrit: Gerrit, patch: Patch):
 
 def find_and_label_all_revision_ids(gerrit: Gerrit, patchset: Patchset):
     for patch in patchset.patches:
-        find_and_label_revision_id(gerrit, patch)
+        _find_and_label_revision_id(gerrit, patch)
 
 def upload_comments_for_patch(gerrit: Gerrit, patch: Patch):
     Comments = List[Dict[str,str]]

--- a/src/patch_parser.py
+++ b/src/patch_parser.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from typing import Dict, List, Optional, Tuple
 import base64
 import pickle

--- a/src/setup_gmail.py
+++ b/src/setup_gmail.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import base64
 import pickle
 import os.path


### PR DESCRIPTION
This code currently uses a lot of unqualified imports of members.

Make the code a bit easier to reason about by removing dead functions and "hiding" a majority of the small helper functions in the codebase.
Also delete ineffectual `__future__` imports given this code only works on Python 3.5+ already.