### PR TITLE
Use deterministic Gerrit ChangeIds

### DIFF
--- a/src/message.py
+++ b/src/message.py
@@ -16,6 +16,9 @@ import email
 import re
 from typing import List, Optional, Tuple
 
+def lore_link(message_id: str) -> str:
+    return 'https://lore.kernel.org/linux-kselftest/' + message_id[1:-1]
+
 class Message(object):
     def __init__(self, id, subject, from_, in_reply_to, content, archive_hash) -> None:
         self.id = id
@@ -52,12 +55,9 @@ class Message(object):
     def __repr__(self) -> str:
         return str(self)
 
-    def lore_link(self) -> str:
-        return 'https://lore.kernel.org/linux-kselftest/' + self.id[1:-1]
-
     def debug_info(self) -> str:
         return (f'Message ID: {self.id}\n'
-                f'Lore Link: {self.lore_link()}\n'
+                f'Lore Link: {lore_link(self.id)}\n'
                 f'Commit Hash: {self.archive_hash}')
 
 def parse_message_from_str(raw_email: str, archive_hash: str) -> Message:


### PR DESCRIPTION
Problem:
Non-deterministic change ids mean we get duplicate changes uploaded to
Gerrit for the same patch if the Bridge gets restarted.

When issue #14 is implemented, this will not matter as much, but there's
still a chance for updates not to be persisted in the DB.

Solution:
Use a deterministic change id, i.e. "I" + <commit sha of v1>.

If we try and create a Gerrit change for the same patch, I'm assuming
the collision with the pre-existing change id will prevent us from doing
so.

Alternative:
As noted in the file, we could consider using a `applypatch-msg` hook.

But we can do more if we edit the commit directly from Python, since we
have access to more information, e.g. the lore link.
Add in a "Lore-Link" footer while we're here to demonstrate this.

This iteration of the code is essentially a direct translation of what I
had originally prototyped in bash for the hook.