### PR TITLE
Add dryrun option and fix some other stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ linux-kselftest
 src/gerrit_git_dir
 src/index_files
 src/logs
+logs/
+gerrit_git_dir/
+index_files/

--- a/src/archive_converter.py
+++ b/src/archive_converter.py
@@ -17,7 +17,7 @@ import os
 from absl import logging
 
 from typing import List, Dict, Optional
-from message import Message, parse_message_from_str
+from message import Message, parse_message_from_bytes
 from message_dao import MessageDao
 
 class ArchiveMessageIndex(object):
@@ -73,9 +73,9 @@ class ArchiveMessageIndex(object):
 
 def generate_email_from_file(file: str) -> Optional[Message]:
     archive_hash = file[12:-4]
-    with open(file, "r") as raw_email:
+    with open(file, "rb") as raw_email:
         try:
-          return parse_message_from_str(raw_email.read(), archive_hash=archive_hash)
+          return parse_message_from_bytes(raw_email.read(), archive_hash=archive_hash)
         except Exception as e:
             logging.error('Failed to generate %s from archive. Error: %s', archive_hash, e)
             return None

--- a/src/gerrit.py
+++ b/src/gerrit.py
@@ -40,7 +40,26 @@ class HTTPCookieAuth(AuthBase):
         request.prepare_cookies(self.cookie_jar)
         return request
 
-class Gerrit(object):
+
+class FakeGerrit(object):
+    def new_change(self, change: Dict[str, Any]):
+        pass
+
+    def get_change(self, change_id: str):
+        pass
+
+    def get_patch(self, change_id: str, revision_id: str):
+        pass
+
+    def get_review(self, change_id: str, revision_id: str):
+        pass
+
+    # TODO: fix type checking issues and set revision_id back to str.
+    def set_review(self, change_id: str, revision_id: Any, review: Dict[str, Any]):
+        pass
+
+
+class Gerrit(FakeGerrit):
     def __init__(self, rest_api: GerritRestAPI) -> None:
         self._rest_api = rest_api
 
@@ -68,6 +87,7 @@ class Gerrit(object):
                         change_id=change_id,
                         revision_id=revision_id),
                 data=review)
+
 
 def _find_and_label_revision_id(gerrit: Gerrit, patch: Patch):
     change_info = gerrit.get_change(patch.change_id)


### PR DESCRIPTION
Couple of commits here. I can break them up if you want.

First commit adds some more stuff to .gitignore.
Second commit adds a --dryrun option to service, basically runs everything as normal without uploading to Gerrit.
Last commit fixes email decoding.