### PR TITLE
Add patch_parser unit tests to demonstrate extant bugs, followed by some cleanups and refactors

### DIFF
--- a/src/patch_parser.py
+++ b/src/patch_parser.py
@@ -334,7 +334,7 @@ def parse_comments(email_thread: Message) -> Patchset:
                                 set_index=set_index,
                                 comments=comments,
                                 change_id=patch.change_id))
-        patch_list.sort(key=lambda x: x.set_index)
+    patch_list.sort(key=lambda x: x.set_index)
     return Patchset(cover_letter=cover_letter, patches=patch_list)
 
 

--- a/src/patch_parser.py
+++ b/src/patch_parser.py
@@ -65,15 +65,6 @@ class CommentLine(object):
         self.child_line_number = child_line_number
         self.text = text
 
-class ProbablyQuoted(Line):
-    def __init__(self, parent_line_number, child_line_number, text) -> None:
-        self.parent_line_number = parent_line_number
-        self.child_line_number = child_line_number
-        self.line_number = child_line_number
-        self.text = text
-
-    def score(self) -> float:
-        return 0.5
 
 class Trie(object):
     def __init__(self) -> None:

--- a/src/patch_parser.py
+++ b/src/patch_parser.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import textwrap
 from typing import Any, Dict, List, Optional, Tuple
 import re
+
 from absl import logging
 from message import Message
 
@@ -363,6 +365,10 @@ class PatchFileChunkLineMap(object):
         else:
             raise IndexError('Expected ' + str(self.in_range[0]) + ' <= ' + str(raw_line) + ' <= ' + str(self.in_range[1]))
 
+    def __repr__(self) -> str:
+        return f'PatchFileLineMap(side={self.side}, offset={self.offset}, range={self.in_range})'
+
+
 class PatchFileLineMap(object):
     def __init__(self, name: str, chunks: List[PatchFileChunkLineMap]) -> None:
         self.name = name
@@ -380,6 +386,10 @@ class PatchFileLineMap(object):
                 return self.name + side, line
         logging.info('%s was not in any chunk', str(raw_line))
         return self.name, -1
+
+    def __repr__(self) -> str:
+        children = '\n'.join(textwrap.indent(repr(c), '  ') for c in self.chunks)
+        return f'PatchFileLineMap(name={self.name} range={self.in_range}\nchunks=\n{children})'
 
 
 class RawLineToGerritLineMap(object):
@@ -399,6 +409,10 @@ class RawLineToGerritLineMap(object):
                 return patch_file.map(raw_line)
         logging.info('%s was not found in patch', str(raw_line))
         return '', -1
+
+    def __repr__(self) -> str:
+        children = '\n'.join(textwrap.indent(repr(p), '  ') for p in self.patch_files)
+        return 'RawLineToGerritLineMap(\n' + children + '\n)'
 
 SKIP_LINE_MATCHER = re.compile(r'^@@ -(\d+)(,\d+)? \+(\d+)(,\d+)? @@.*$')
 

--- a/src/patch_parser.py
+++ b/src/patch_parser.py
@@ -18,13 +18,13 @@ from absl import logging
 from message import Message
 
 class Comment(object):
-    def __init__(self, raw_line, message) -> None:
+    def __init__(self, raw_line, message: str, file: Optional[str] = None, line: Optional[int] = None) -> None:
         self.raw_line = raw_line
         self.message = message
         # TODO: is this field used anymore?
         self.children = []  # type: List[Any]
-        self.line = None
-        self.file = None
+        self.file = file
+        self.line = line
 
 class CoverLetter(object):
     def __init__(self, text, comments: List[Comment]) -> None:

--- a/src/patch_parser.py
+++ b/src/patch_parser.py
@@ -570,7 +570,8 @@ def _parse_patch_file_entry(lines: List[str], index: int) -> Optional[PatchFileL
         raise ValueError('Expected chunks in file, but found: ' + lines[0])
     return PatchFileLineMap(name=file_name, chunks=chunks)
 
-def _parse_patch_header(lines: List[str]) -> int:
+def _find_diff_start(lines: List[str]) -> int:
+    """Finds the start of the actual diff, after the commit message and the diffstat."""
     index = 0
 
     # Ignore everything before last '---'.
@@ -613,7 +614,7 @@ def _parse_patch_header(lines: List[str]) -> int:
 def _parse_git_patch(raw_patch: str) -> RawLineToGerritLineMap:
     lines = raw_patch.split('\n')
     lines = [line.strip() for line in lines]
-    index = _parse_patch_header(lines)
+    index = _find_diff_start(lines)
     file_entries = []
     file_entry = _parse_patch_file_entry(lines, index)
     while file_entry:

--- a/src/patch_parser.py
+++ b/src/patch_parser.py
@@ -23,8 +23,6 @@ class Comment(object):
     def __init__(self, raw_line, message: str, file: Optional[str] = None, line: Optional[int] = None) -> None:
         self.raw_line = raw_line
         self.message = message
-        # TODO: is this field used anymore?
-        self.children = []  # type: List[Any]
         self.file = file
         self.line = line
 

--- a/src/patch_parser.py
+++ b/src/patch_parser.py
@@ -49,18 +49,19 @@ class Patchset(object):
         self.patches = patches
 
 class Line(object):
-    def __init__(self, line_number, text) -> None:
+    """A line of text that tracks its line number."""
+    def __init__(self, line_number: int, text: str) -> None:
         self.line_number = line_number
         self.text = text
 
 class QuotedLine(object):
-    def __init__(self, parent_line_number, child_line_number, text) -> None:
+    def __init__(self, parent_line_number: int, child_line_number: int, text: str) -> None:
         self.parent_line_number = parent_line_number
         self.child_line_number = child_line_number
         self.text = text
 
 class CommentLine(object):
-    def __init__(self, last_parent_line_number, child_line_number, text) -> None:
+    def __init__(self, last_parent_line_number: int, child_line_number: int, text: str) -> None:
         self.last_parent_line_number = last_parent_line_number
         self.child_line_number = child_line_number
         self.text = text
@@ -222,10 +223,8 @@ def _find_quoted_lines(parent_lines: List[Line],
 
 def _to_lines(text: str) -> List[Line]:
     line_list = []
-    line_number = 0
-    for line in text.splitlines():
-        line_list.append(Line(text=line, line_number=line_number))
-        line_number += 1
+    for i, line in enumerate(text.splitlines()):
+        line_list.append(Line(text=line, line_number=i))
     return line_list
 
 def _filter_definitely_comments(child_lines: List[Line]) -> List[Line]:

--- a/src/patch_parser_test.py
+++ b/src/patch_parser_test.py
@@ -1,5 +1,5 @@
 import unittest
-from patch_parser import parse_comments
+from patch_parser import parse_comments, map_comments_to_gerrit, Comment
 from archive_converter import ArchiveMessageIndex, generate_email_from_file
 from message_dao import MessageDao
 
@@ -7,6 +7,15 @@ from test_helpers import test_data_path
 
 
 class PatchParserTest(unittest.TestCase):
+
+    def compareCommentsPartialMatch(self, gotComments, wantComments):
+        self.assertEqual(len(gotComments), len(wantComments))
+        for got, want in zip(gotComments, wantComments):
+            self.assertEqual(got.message.strip(), want.message)
+            self.assertEqual(got.raw_line, want.raw_line)
+            self.assertEqual(got.file, want.file)
+            self.assertEqual(got.line, want.line)
+
 
     def test_parse_comments_for_single_email_thread(self):
         archive_index = ArchiveMessageIndex(MessageDao())
@@ -39,6 +48,34 @@ class PatchParserTest(unittest.TestCase):
         patchset = parse_comments(generate_email_from_file(test_data_path('thread_patch0.txt')))
 
         self.assertEqual(len(patchset.patches), 0)
+
+    def test_parse_with_replies(self):
+        archive_index = ArchiveMessageIndex(MessageDao())
+        archive_index.update(test_data_path('fake_patch_with_replies/'))
+
+        self.assertEqual(archive_index.size(), 2)
+
+        patchset = parse_comments(archive_index.find('<patch-message-id>'))
+        map_comments_to_gerrit(patchset)
+        self.assertEqual(len(patchset.patches), 1)
+
+        patch = patchset.patches[0]
+
+        self.compareCommentsPartialMatch(patch.comments, [
+            # TODO: stop treating this as a comment
+            Comment(raw_line=-1,
+                    file='',
+                    line=-1,
+                    message='On Mon, 31 Aug 2020 at 12:04:46 +0100, The Sender wrote:'),
+            Comment(raw_line=18,
+                    file='file',
+                    line=7, # TODO: should be 5
+                    message='Comment on old line 5, want on line 5 in new file.'),
+            Comment(raw_line=20,
+                    file='file',
+                    line=9,  # TODO: should be 7
+                    message='Comment on old line 7, want on line 8 in new file.'),
+        ])
 
     #TODO(willliu@google.com): Add tests for Multiple patches, no cover letter
 

--- a/src/test_data/fake_patch_with_replies/patch.txt
+++ b/src/test_data/fake_patch_with_replies/patch.txt
@@ -1,0 +1,35 @@
+From:   The Sender <sender@email.org>
+To:     reviewer@email.org, linux-kernel@vger.kernel.org
+Cc:     cc@email.com,
+Subject: [PATCH] subsystem: change things
+Date:   Mon, 31 Aug 2020 12:04:46 +0100
+Message-Id: <patch-message-id>
+
+This is the patch description.
+
+Signed-off-by: The Sender <sender@email.org>
+
+---
+ file | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/file b/file
+index fa2da6e55caa..1fc93eb38351 100644
+--- a/file
++++ b/file
+@@ -2,7 +2,8 @@ line 1
+ line 2
+ line 3
+ line 4
+-line 5
++line 5 - edit
++  inserted new line
+ line 6
+ line 7
+ line 8
+
+base-commit: 235360eb7cd778d7264c5e57358a3d144936b862
+--
+2.17.1
+
+

--- a/src/test_data/fake_patch_with_replies/reply.txt
+++ b/src/test_data/fake_patch_with_replies/reply.txt
@@ -1,0 +1,41 @@
+From: <reviewer@email.org>
+To:   <sender@email.org>
+Cc:   cc@email.com, linux-kernel@vger.kernel.org
+In-Reply-To: <patch-message-id>
+Date:   Mon, 31 Aug 2020 12:04:46 +0100
+Message-Id: <reply-message-id>
+Subject: Re: [PATCH] subsystem: change things
+
+On Mon, 31 Aug 2020 at 12:04:46 +0100, The Sender wrote:
+> This is the patch description.
+> 
+> Signed-off-by: The Sender <sender@email.org>
+> 
+> ---
+>  file | 3 ++-
+>  1 file changed, 2 insertions(+), 1 deletion(-)
+> 
+> diff --git a/file b/file
+> index fa2da6e55caa..1fc93eb38351 100644
+> --- a/file
+> +++ b/file
+> @@ -2,7 +2,8 @@ line 1
+>  line 2
+>  line 3
+>  line 4
+> -line 5
+> +line 5 - edit
+> +  inserted new line
+
+Comment on old line 5, want on line 5 in new file.
+
+>  line 6
+>  line 7
+
+Comment on old line 7, want on line 8 in new file.
+
+>  line 8
+> 
+> base-commit: 235360eb7cd778d7264c5e57358a3d144936b862
+> --
+> 2.17.1


### PR DESCRIPTION
The first patch (92290a1d4dbd) adds in a pair of fake messages, one with a tiny diff:

```
diff --git a/file b/file
index fa2da6e55caa..1fc93eb38351 100644
--- a/file
+++ b/file
@@ -2,7 +2,8 @@ line 1
 line 2
 line 3
 line 4
-line 5
+line 5 - edit
+  inserted new line
```

and another that's a reply to it.
I've tracked down at least one of the issues for the comments being off to `_parse_git_patch()`, and introduced a small test case for that as well (8ea9d347e0).

Everything else is cleanups + cosmetic changes (which are now finally tested enough to make with some level of confidence).
By far the most involved is the last one (b95fbc9524c), which reduces the amount of state being passed around and prevents a possible class of line number off-by-one bugs.


