### PR TITLE
Update EPOCH_HASH to use something from the last month

### DIFF
--- a/src/archive_updater.py
+++ b/src/archive_updater.py
@@ -60,7 +60,7 @@ def setup_archive(archive_path : str):
                            'linux-kselftest/git/0.git'])
 
 def main() -> None:
-    print(fill_message_directory('../linux-kselftest/git/0.git', '../lkml-gerrit-bridge/test_data', 'cc49e216e3fdff0ffed7675dc7215aba5e3d05cc'))
+    print(fill_message_directory('../linux-kselftest/git/0.git', '../lkml-gerrit-bridge/test_data', 'ae9e7be4a03765456fe38287533e6446e8bbc93c'))
 
 if __name__ == '__main__':
     main()

--- a/src/message_dao.py
+++ b/src/message_dao.py
@@ -15,7 +15,7 @@
 from typing import Dict, Optional
 from message import Message
 
-EPOCH_HASH = 'cc49e216e3fdff0ffed7675dc7215aba5e3d05cc'
+EPOCH_HASH = 'ae9e7be4a03765456fe38287533e6446e8bbc93c'
 
 class MessageDao(object):
 


### PR DESCRIPTION
Last time we updated the EPOCH_HASH was over a year ago, so the bridge
has to go through a lot of really old emails before getting to anything
current. Update it to something more recent.

Signed-off-by: Brendan Higgins <brendanhiggins@google.com>