### PR TITLE
Fix is_patch() so it returns False on cover letters

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -105,7 +105,7 @@ class Server(object):
             if message.is_patch():
                 messages_to_upload.append(message.id)
             # Reply is a comment that's parent is not in this batch of messages. Its parent's comments should be reuploaded
-            else:
+            elif not message.is_coverletter():
                 messages_with_new_comments.add(message.in_reply_to)
 
         self.upload_messages(messages_to_upload)

--- a/src/message.py
+++ b/src/message.py
@@ -31,14 +31,25 @@ class Message(object):
         self.archive_hash = archive_hash
         self.children = []  # type: List[Message]
 
-    def is_patch(self) -> bool:
+    def _is_patch_or_coverletter(self) -> bool:
         if re.match(r'\[.+\] .+', self.subject):
             return True
         return False
 
+    def is_patch(self) -> bool:
+        if self._is_patch_or_coverletter():
+            return self._patch_index()[0] > 0
+        return False
+
+    def is_coverletter(self) -> bool:
+        return self._is_patch_or_coverletter() and not self.is_patch()
+
     def patch_index(self) -> Tuple[int, int]:
-        if not self.is_patch():
-            raise ValueError(f'Missing patch index in subject: {self.subject}')
+         if not self._is_patch_or_coverletter():
+             raise ValueError(f'Missing patch index in subject: {self.subject}')
+         return self._patch_index()
+
+    def _patch_index(self) -> Tuple[int, int]:
         match = re.match(r'\[.+ (\d+)/(\d+)\] .+', self.subject)
         if match:
             return int(match.group(1)), int(match.group(2))


### PR DESCRIPTION
is_patch() is a method on Message objects that we use to determine
whether we should treat an email message as a patch or not. Currently,
it returns True for the cover letter of a patch set - fix this.

Signed-off-by: Brendan Higgins <brendanhiggins@google.com>