### PR TITLE
Update .gitignore to ignore temp dirs, vim temp files, and git temp f…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,12 @@ __pycache__
 linux-kselftest
 src/gerrit_git_dir
 src/index_files
+gerrit_git_dir/
+index_files/
 src/logs
 .idea/
 logs/
 venv/
 .DS_Store
+*.orig
+*.swp


### PR DESCRIPTION
…iles

Update gitignore to ignore temp dirs created by running the bridge
locally, along with vim temp files, and git temp files.

Signed-off-by: Brendan Higgins <brendanhiggins@google.com>