### PR TITLE
Database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ credentials.json
 token.pickle
 index.pickle
 gerritcookies
+.env
 __pycache__
 # The following directories are generated during runtime and are used to assist
 # some of the functionality of lkml-gerrit-bridge. However, they are not

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # set base image (host OS)
 FROM python:3.8
 
+# allow Google API to utilize downloaded credentials
+ENV GOOGLE_APPLICATION_CREDENTIALS credentials.json
+
 # set the working directory in the container
 WORKDIR /code
 
@@ -9,6 +12,9 @@ COPY requirements.txt .
 
 # copy the gerrit cookies file to the working directory
 COPY gerritcookies .
+
+# copy the gcloud credentials file to the working directory
+COPY credentials.json .
 
 # install dependencies
 RUN pip3 install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ you have to:
 Then you need to copy the credentials file that was added to a file called 
 `credentials.json` in this directory.
 
+### Setting up Database information
+
+Create a file named `.env` under `src/` that includes all of the following:
+
+```
+HOST = [HOST_NAME]
+USER = [USER_NAME]
+PASSWORD = [PASSWORD]
+DB = [NAME_OF_DATABASE]
+
+NOTE: The name of the database does not have to be an existing database.
+```
+
 ### Building a docker image
 
 First, make sure that you have Docker installed on the device which is building

--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ Then you need to copy the cookies that were added to a file called
 
 NOTE: YOU MUST ADD A COMMENT TO THE TOP OF THE COOKIE FILE: `# HTTP Cookie File`
 
+### Setting up Google Cloud credentials
+
+First you need to generate the gcloud credentials file. In order to do that,
+you have to:
+
+- Download gcloud CLI (follow instructions on https://cloud.google.com/sdk/docs/install)
+- Run `gcloud auth appplication-default login` in the terminal
+
+Then you need to copy the credentials file that was added to a file called 
+`credentials.json` in this directory.
+
 ### Building a docker image
 
 First, make sure that you have Docker installed on the device which is building

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ absl-py==0.10.0
 pygerrit2==2.0.13
 requests==2.24.0
 requests-oauthlib==1.3.0
+cloud-sql-python-connector[pymysql]==0.6.2
+python-dotenv==0.20.0

--- a/src/archive_converter_test.py
+++ b/src/archive_converter_test.py
@@ -1,12 +1,15 @@
 import unittest
 from archive_converter import generate_email_from_file, ArchiveMessageIndex
-from message_dao import MessageDao
+from message_dao import FakeMessageDao
 from typing import List
 from message import Message
 
 from test_helpers import compare_message_subjects, test_data_path
 
 class ArchiveConverterTest(unittest.TestCase):
+
+    def setUp(self):
+        self.message_dao = FakeMessageDao()
 
     def test_generate_email_from_single_email_thread(self):
         email = generate_email_from_file(test_data_path('patch6.txt'))
@@ -16,15 +19,15 @@ class ArchiveConverterTest(unittest.TestCase):
         self.assertTrue(len(email.content) > 0)
 
     def test_update_with_no_changes_to_data(self):
-        archive_index = ArchiveMessageIndex(MessageDao())
+        archive_index = ArchiveMessageIndex(self.message_dao)
         archive_index.update(test_data_path())
-        old_size = archive_index.size()
+        old_size = self.message_dao.size()
         archive_index.update(test_data_path())
-        self.assertEqual(old_size, archive_index.size())
+        self.assertEqual(old_size, self.message_dao.size())
 
     def test_update_return_proper_patches(self):
-        archive_index = ArchiveMessageIndex(MessageDao())
-        new_messages = archive_index.update(test_data_path())
+        archive_index = ArchiveMessageIndex(self.message_dao)
+        new_messages = archive_index.update(test_data_path()).values()
         self.assertEqual(len(new_messages), 8)
 
         subjects = ['Re: [PATCH] Remove final reference to superfluous smp_commence().',

--- a/src/main.py
+++ b/src/main.py
@@ -22,12 +22,12 @@ from absl import logging
 import archive_updater
 import gerrit
 import git
-import message_dao
 import patch_parser
 
 from archive_converter import ArchiveMessageIndex
 from message import Message
-from typing import Collection, List, Set, Tuple
+from message_dao import MessageDao
+from typing import Collection, Dict, List, Set, Tuple
 
 GIT_PATH = '../linux-kselftest/git/0.git'
 FILE_DIR = 'index_files'
@@ -40,7 +40,7 @@ WAIT_TIME = 10
 #TODO(@willliu): consider adding more specific errors to raise, instead of a catch-all
 
 class Server(object):
-    def __init__(self) -> None:
+    def __init__(self, message_dao : MessageDao) -> None:
         rest = gerrit.get_gerrit_rest_api(COOKIE_JAR_PATH, GERRIT_URL)
         self.gerrit = gerrit.Gerrit(rest)
         self.gerrit_git = git.GerritGit(git_dir='gerrit_git_dir',
@@ -48,7 +48,7 @@ class Server(object):
                                         url=GOB_URL,
                                         project='linux/kernel/git/torvalds/linux',
                                         branch='master')
-        self.message_dao = message_dao.MessageDao()
+        self.message_dao = message_dao
         self.archive_index = ArchiveMessageIndex(self.message_dao)
         self.last_hash = self.message_dao.get_last_hash()
         archive_updater.setup_archive(GIT_PATH)
@@ -83,82 +83,96 @@ class Server(object):
         new_messages = self.update_message_dir()
 
         # Differentiate between messages to upload and comments
-        messages_to_upload : List[str] = []
-        messages_with_new_comments : Set[str] = set()
+        messages_to_upload : List[Message] = []
+        messages_with_new_comments : Dict[str, Message] = {}
         parent_patches : Set[str] = set()
+        replies_to_store : List[Message] = []
         # First separate between parents and replies. All parents of patchsets will be uploaded
-        parents, replies = self.split_parent_and_reply_messages(new_messages)
+        parents, replies = self.split_parent_and_reply_messages(new_messages.values())
 
         for message in parents:
             parent_patches.add(message.id)
-            messages_to_upload.append(message.id)
+            messages_to_upload.append(message)
 
         # Determine which of the replies should be uploaded
         for message in replies:
             if message.in_reply_to in parent_patches:
+                replies_to_store.append(message)
                 continue
-
-            if not self.message_dao.get(message.in_reply_to):
+            if not new_messages.get(message.in_reply_to) and not self.message_dao.get(message.in_reply_to):
                 continue
-
+            replies_to_store.append(message)
             # Reply is a patch to be uploaded (as the parent of patchset is not in new_messages)
             if message.is_patch():
-                messages_to_upload.append(message.id)
+                messages_to_upload.append(message)
             # Reply is a comment that's parent is not in this batch of messages. Its parent's comments should be reuploaded
             elif not message.is_coverletter():
-                messages_with_new_comments.add(message.in_reply_to)
+                parent = new_messages.get(message.in_reply_to)
+                if not parent:
+                    parent = self.message_dao.get(message.in_reply_to)
+                messages_with_new_comments[parent.id] = parent
 
         self.upload_messages(messages_to_upload)
 
         self.upload_comments(messages_with_new_comments)
 
+        self.store_replies(replies_to_store)
+
+        self.message_dao.store_last_hash(self.last_hash)
+
         self.remove_files(FILE_DIR)
 
-    def update_message_dir(self) -> List[Message]:
+    def update_message_dir(self) -> Dict[str, Message]:
         self.last_hash = archive_updater.fill_message_directory(GIT_PATH, FILE_DIR, self.last_hash)
         messages = self.archive_index.update(FILE_DIR)
         return messages
 
-    def upload_messages(self, messages_to_upload : List[str]):
+    def upload_messages(self, messages_to_upload : List[Message]):
         failed = 0
-        for message_id in messages_to_upload:
-            email_thread : Message
+        for email_thread in messages_to_upload:
             try:
-                email_thread = self.archive_index.find(message_id)
                 patchset = patch_parser.parse_comments(email_thread)
-                self.gerrit_git.apply_patchset_and_cleanup(patchset, self.message_dao)
+                self.gerrit_git.apply_patchset_and_cleanup(patchset, email_thread, self.message_dao)
                 gerrit.find_and_label_all_revision_ids(self.gerrit, patchset)
                 gerrit.upload_all_comments(self.gerrit, patchset)
             except Exception as e:
                 failed += 1
-                failed_message = message_id
-                if email_thread:
-                    failed_message = email_thread.debug_info()
+                failed_message = email_thread.debug_info()
                 logging.exception('Failed to upload %s.', failed_message)
                 continue
         if failed > 0:
             logging.warning('Failed to upload %d/%d messages', failed, len(messages_to_upload))
 
-    def upload_comments(self, messages_with_new_comments : Collection[str]):
+    def upload_comments(self, messages_with_new_comments : Dict[str, Message]):
         failed = 0
-        for message_id in messages_with_new_comments:
-            email_thread : Message
+        for email_thread in messages_with_new_comments.values():
             try:
-                email_thread = self.archive_index.find(message_id)
                 patchset = patch_parser.parse_comments(email_thread)
                 gerrit.upload_all_comments(self.gerrit, patchset)
+                self.message_dao.store(email_thread)
             except Exception as e:
                 failed += 1
-                failed_message = message_id
-                if email_thread:
-                    failed_message = email_thread.debug_info()
+                failed_message = email_thread.debug_info()
                 logging.exception('Failed to upload comments for %s.', failed_message)
                 continue
         if failed > 0:
             logging.warning('Failed to upload %d/%d comments', failed, len(messages_with_new_comments))
 
+    def store_replies(self, replies : Collection[Message]):
+        failed = 0
+        for reply in replies:
+            try:
+                self.message_dao.store(reply)
+            except Exception as e:
+                failed += 1
+                failed_reply = reply.debug_info()
+                logging.exception('Failed to upload %s.', failed_reply)
+                continue
+        if failed > 0:
+            logging.warning('Failed to upload %d/%d replies', failed, len(replies))
+
 def main(argv) -> None:
-    server = Server()
+    server = Server(MessageDao(GIT_PATH))
     server.run()
 
 

--- a/src/message.py
+++ b/src/message.py
@@ -24,6 +24,7 @@ class Message(object):
     def __init__(self, id, subject, from_, in_reply_to, content, archive_hash) -> None:
         self.id = id
         self.subject = subject
+        self.normalized_subject = self._normalize_subject()
         self.from_ = from_
         self.in_reply_to = in_reply_to
         self.content = content
@@ -55,6 +56,9 @@ class Message(object):
             return int(match.group(1)), int(match.group(2))
         return (1, 1)
 
+    def _normalize_subject(self) -> str:
+        return self.subject.partition("] ")[2].lower()
+
     def __str__(self) -> str:
         in_reply_to = self.in_reply_to or ''
         return ('{\n' +
@@ -66,6 +70,14 @@ class Message(object):
 
     def __repr__(self) -> str:
         return str(self)
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, Message):
+            return False
+        return (self.id == other.id and self.subject == other.subject
+        and self.from_ == other.from_ and self.in_reply_to == other.in_reply_to
+        and self.content == other.content and self.change_id == other.change_id
+        and self.archive_hash == other.archive_hash and self.children == other.children)
 
     def debug_info(self) -> str:
         return (f'Message ID: {self.id}\n'

--- a/src/message_dao.py
+++ b/src/message_dao.py
@@ -12,27 +12,139 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Optional
-from message import Message
+import json
+import os
+import subprocess
 
+from functools import lru_cache
+from typing import Dict, List, Optional
+
+from dotenv import load_dotenv
+from google.cloud.sql.connector import Connector
+from message import lore_link, Message, parse_message_from_str
+
+load_dotenv()
 EPOCH_HASH = 'ae9e7be4a03765456fe38287533e6446e8bbc93c'
 
 class MessageDao(object):
+    def __init__(self, archive_path: str) -> None:
+        """ Creates a connection as well as two tables: Messages and States.
+        Message stores the messages we've uploaded and States is a key-value
+        store which tracks things like 'last_hash', the last Lore git commit
+        we've processed."""
+        self._initialize_connection()
+        self._initialize_tables()
+        self.archive_path = archive_path
 
+    def _initialize_connection(self) -> None:
+        connector = Connector()
+        self.connection = connector.connect(
+            os.environ.get("HOST"),
+            "pymysql",
+            user = os.environ.get("USER"),
+            password = os.environ.get("PASSWORD")
+        )
+    
+    def _initialize_tables(self) -> None:
+        db_name = os.environ.get("DB")
+        if not db_name:
+            raise Exception("Missing environment variable for name of database.")
+        with self.connection.cursor() as cursor:
+            cursor.execute("CREATE DATABASE IF NOT EXISTS " + db_name)
+            self.connection.select_db(db_name)
+            # Mapping from message id to message
+            cursor.execute(
+                "CREATE TABLE IF NOT EXISTS Messages"
+                "(message_id VARCHAR(255) NOT NULL,"
+                "normalized_subject VARCHAR(255) NOT NULL,"
+                "from_ VARCHAR(255) NOT NULL,"
+                "in_reply_to VARCHAR(255),"
+                "archive_hash VARCHAR(255) NOT NULL,"
+                "change_id VARCHAR(255),"
+                "lore_link VARCHAR(255),"
+                "PRIMARY KEY (message_id))"
+            )
+            # Mapping from name of state attribute to state
+            cursor.execute(
+                "CREATE TABLE IF NOT EXISTS States"
+                "(state_name VARCHAR(255) NOT NULL,"
+                "value VARCHAR(255) NOT NULL,"
+                "PRIMARY KEY (state_name))"
+            )
+        self.connection.commit()
+
+    def store(self, message: Message) -> None:
+        link = lore_link(message.id)
+        query = "REPLACE INTO Messages VALUES (%s, %s, %s, %s, %s, %s, %s)"
+        with self.connection.cursor() as cursor:
+            cursor.execute(query, (message.id, message.normalized_subject, message.from_,
+            message.in_reply_to, message.archive_hash, message.change_id, link))
+        if message.in_reply_to:
+            # Clear cache because the parent's cache is no longer valid: list of children changed
+            self.get.cache_clear()
+        self.connection.commit()
+
+    def _get_children(self, message_id: str) -> List[Optional[Message]]:
+        query = "SELECT * FROM Messages WHERE in_reply_to=%s"
+        with self.connection.cursor() as cursor:
+            cursor.execute(query, (message_id,))
+            res = cursor.fetchall()
+        return [self.get(tup[0]) for tup in res]
+
+    @lru_cache
+    def get(self, message_id: str) -> Optional[Message]:
+        query = "SELECT archive_hash, change_id FROM Messages WHERE message_id=%s"
+        with self.connection.cursor() as cursor:
+            cursor.execute(query, (message_id,))
+            res = cursor.fetchone()
+        if res is None:
+            return None
+        archive_hash, change_id = res[0], res[1]
+        # Recreate the message object using the archive hash
+        raw_email = subprocess.check_output(['git', '-C', self.archive_path, 'show', f'{archive_hash}:m'])
+        msg = parse_message_from_str(raw_email.decode(), archive_hash=archive_hash)
+        msg.change_id = change_id
+        msg.children = self._get_children(message_id)
+        return msg
+
+    def size(self) -> int:
+        query = "SELECT COUNT(*) FROM Messages"
+        with self.connection.cursor() as cursor:
+            cursor.execute(query)
+            res = cursor.fetchone()
+        return res[0]
+
+    def store_last_hash(self, last_hash: str) -> None:
+        query = "REPLACE INTO States VALUES (%s, %s)"
+        with self.connection.cursor() as cursor:
+            cursor.execute(query, ("last_hash", last_hash))
+        self.connection.commit()
+
+    def get_last_hash(self) -> str:
+        query = "SELECT value FROM States WHERE state_name=%s"
+        with self.connection.cursor() as cursor:
+            cursor.execute(query, ("last_hash"))
+            res = cursor.fetchone()
+        return EPOCH_HASH if res is None else res[0]
+
+
+class FakeMessageDao(MessageDao):
     def __init__(self) -> None:
         # Maps message.id to message
-        self._messages_seen : Dict[str, Message] = {}
+        self._messages_seen = {}
+        self.last_hash = EPOCH_HASH
 
-    def store(self, message : Message) -> None:
+    def store(self, message: Message) -> None:
         self._messages_seen[message.id] = message
 
-    def get(self, message_id : str) -> Optional[Message]:
+    def get(self, message_id: str) -> Optional[Message]:
         return self._messages_seen.get(message_id)
 
     def size(self) -> int:
         return len(self._messages_seen)
 
-    # This function is currently hardcoded because it will not be used until post database integration.
-    # TODO (@willliu): if empty, then return epoch hash. o/w return latest set hash.
-    def get_last_hash(self) -> str:
-        return EPOCH_HASH
+    def store_last_hash(self, last_hash: str) -> None:
+        self.last_hash = last_hash
+
+    def get_last_hash(self) -> int:
+        return self.last_hash

--- a/src/message_dao_test.py
+++ b/src/message_dao_test.py
@@ -1,0 +1,88 @@
+import unittest
+import subprocess
+import zlib
+
+from unittest import mock
+from google.cloud.sql.connector import Connector
+
+import message
+import message_dao
+import archive_converter
+from test_helpers import test_data_path
+
+class StrContains(str):
+   def __eq__(self, other):
+      return self in other
+
+class MessageDaoTest(unittest.TestCase):
+
+    def setUp(self):
+        self.addCleanup(mock.patch.stopall)
+        self.mock_connect = mock.patch.object(Connector, 'connect').start()
+        mock_connection = self.mock_connect.return_value
+        self.mock_commit = mock_connection.commit
+        self.mock_cursor = mock_connection.cursor.return_value.__enter__.return_value
+        self.mock_execute = self.mock_cursor.execute
+        # Check initialization of DAO
+        self.dao = message_dao.MessageDao('FAKE_GIT_PATH')
+        self.mock_connect.assert_called_once()
+        self.mock_commit.assert_called_once()
+        self.assertEqual(3, self.mock_execute.call_count)
+        self.mock_execute.reset_mock()
+        self.mock_commit.reset_mock()
+        self.mock_connect.side_effect = RuntimeError("Shouldn't be called after init")
+
+    def test_store(self):
+        email = archive_converter.generate_email_from_file(test_data_path('patch6.txt'))
+        sql_text = "REPLACE INTO Messages VALUES (%s, %s, %s, %s, %s, %s, %s)"
+        self.dao.store(email)
+        self.mock_execute.assert_called_once_with(sql_text, mock.ANY)
+        self.mock_commit.assert_called_once()
+
+    @mock.patch.object(subprocess, 'check_output')
+    @mock.patch.object(message_dao, 'parse_message_from_str')
+    def test_get(self, mock_parse_msg, mock_check_output):
+        self.mock_commit.side_effect = RuntimeError("Shouldn't be called during get")
+        email = archive_converter.generate_email_from_file(test_data_path('patch6.txt'))
+        mock_parse_msg.return_value = email
+        self.mock_cursor.fetchone.return_value = (email.archive_hash, email.change_id)
+        self.assertEqual(email, self.dao.get('fake_message_id'))
+        self.assertEqual(2, self.mock_execute.call_count)
+        self.mock_execute.assert_has_calls([
+            mock.call(StrContains("WHERE message_id=%s"), mock.ANY),  # get this msg
+            mock.call(StrContains("WHERE in_reply_to=%s"), mock.ANY),  # get children
+        ])
+
+    def test_get_missing(self):
+        self.mock_commit.side_effect = RuntimeError("Shouldn't be called during get")
+        self.mock_cursor.fetchone.return_value = None
+        self.assertIsNone(self.dao.get('not_in_dao'))
+        self.mock_execute.assert_called_once()
+
+    def test_size(self):
+        self.mock_cursor.fetchone.return_value = (1,)
+        self.assertEqual(1, self.dao.size())
+        self.mock_execute.assert_called_once()
+
+    def test_store_hash(self):
+        self.dao.store_last_hash("some_hash")
+        sql_text = "REPLACE INTO States VALUES (%s, %s)"
+        self.mock_execute.assert_called_once_with(sql_text, mock.ANY)
+        self.mock_commit.assert_called_once()
+
+    def test_get_hash(self):
+        self.mock_commit.side_effect = RuntimeError("Shouldn't be called during get_hash")
+        self.mock_cursor.fetchone.return_value = ("fake_hash",)
+        self.assertEqual("fake_hash", self.dao.get_last_hash())
+        self.mock_execute.assert_called_once()
+
+    def test_get_hash_missing(self):
+        self.mock_commit.side_effect = RuntimeError("Shouldn't be called during get_hash")
+        self.mock_cursor.fetchone.return_value = None
+        self.assertEqual(message_dao.EPOCH_HASH, self.dao.get_last_hash())
+        self.mock_execute.assert_called_once()
+
+if __name__ == '__main__':
+    # TODO(lenhard@google.com): Issue with Google's Connector that causes segmentation fault
+    # unittest.main()
+    pass


### PR DESCRIPTION
Previously, messages would be stored into the database immediately after being processed. Now, instead, a dictionary (local_mapping) is used to handle the intermediate processing that occurs before pushing patches onto Gerrit, thus the database stores patches only once a patch has been posted onto Gerrit. 

There was an issue within git.py where the GERRIT_PUSH_MATCHER constraint was too strong such that some pushes weren't being matched properly. Thus, it was modified to look for just the `success` portion of the push result as this is the only part that's needed to determine the change url.